### PR TITLE
78 pre existing mapping object

### DIFF
--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -767,12 +767,16 @@ class Salesforce_Pull {
 						}
 
 						// find out if there is a mapping object for this wordpress object already
-						$mapping_object = $this->mappings->get_object_maps(
-							array(
-								'wordpress_id' => $wordpress_id,
-								'wordpress_object' => $salesforce_mapping['wordpress_object'],
-							)
-						);
+						// don't do it if the wordpress id is 0.
+						if ( 0 !== $wordpress_id ) {
+							$mapping_object = $this->mappings->get_object_maps(
+								array(
+									'wordpress_id' => $wordpress_id,
+									'wordpress_object' => $salesforce_mapping['wordpress_object'],
+								)
+							);
+						} // End if().
+						// we might want to log something here, but i'm not sure
 
 						// there is already a mapping object. don't change the wordpress data to match this new salesforce record, but log it
 						if ( isset( $mapping_object['id'] ) ) {


### PR DESCRIPTION
I don't think this entirely fixes #78 as there may still be rows with a wordpress id of 0 that never gets updated. I think maybe we need more logging to discover this. But this does allow new rows to be created, I think, and that was being prevented if there was one of these rows.