### PR TITLE
Include error code in SalesforceException message when unable to get SF access token

### DIFF
--- a/classes/salesforce.php
+++ b/classes/salesforce.php
@@ -535,7 +535,15 @@ class Salesforce {
 
 		if ( 200 !== $response['code'] ) {
 			// @TODO: Deal with error better.
-			throw new SalesforceException( esc_html__( 'Unable to get a Salesforce access token.', $this->text_domain ), $response['code'] );
+			throw new SalesforceException(
+				esc_html(
+					sprintf(
+						__( 'Unable to get a Salesforce access token. Salesforce returned the following errorCode: ', $this->text_domain ).
+						$response['code']
+					)
+				),
+				$response['code']
+			);
 		}
 
 		$data = $response['data'];


### PR DESCRIPTION
For #4, include the HTTP `errorCode` returned by the Salesforce API in the error message, since the second parameter on `new Exception` doesn't end up in the message: https://github.com/MinnPost/object-sync-for-salesforce/issues/4#issuecomment-302466891