### PR TITLE
Remove bad mappings from the submitted mapping before saving

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -279,6 +279,16 @@ class Salesforce_Mapping {
 						'direction' => sanitize_text_field( $posted['direction'][ $key ] ),
 						'is_delete' => sanitize_text_field( $posted['is_delete'][ $key ] ),
 					);
+
+					// if the wordpress key or the salesforce key are blank, remove this incomplete mapping
+					// this prevents https://github.com/MinnPost/object-sync-for-salesforce/issues/82
+					if (
+						empty( $setup['fields'][ $key ][ 'wordpress_field' ][ 'label' ] )
+						||
+						empty( $setup['fields'][ $key ][ 'salesforce_field' ][ 'label' ] )
+					) {
+						unset( $setup['fields'][ $key ] );
+					}
 				}
 			}
 			$data['fields'] = maybe_serialize( $setup['fields'] );


### PR DESCRIPTION
## Changes

When saving a new or edited mapping, if the mapping's Wordpress or Salesforce field choice is empty, do not save that mapping.

## Why

This is for #82, where API errors were being caused by mappings having no field, and thus generating invalid API calls to Salesforce. Not-saving the mapping means that the invalid mapping will not be used as part of the API call.

This has a side effect of cleaning empty field mappings from the admin without the need for the user to check the "delete" box for that row:
<img width="1106" alt="screen shot 2017-05-22 at 1 22 44 pm" src="https://cloud.githubusercontent.com/assets/1754187/26320696/cfcf6910-3ef1-11e7-975d-ec354b148677.png">

