### PR TITLE
Upgrade a notice to an error because it prevents items being saved

### DIFF
--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -2215,7 +2215,6 @@ class Wordpress {
 					'method_read' => $methods['method_read'],
 				);
 			} elseif ( count( $comments ) > 1 ) {
-				$status = 'notice';
 				// create log entry for multiple matches
 				if ( isset( $this->logging ) ) {
 					$logging = $this->logging;
@@ -2223,11 +2222,18 @@ class Wordpress {
 					$logging = new Salesforce_Logging( $this->wpdb, $this->version, $this->text_domain );
 				}
 				$logging->setup(
-					__( ucfirst( $status ) . ': Comments: there are ' . $count . ' comment matches for the Salesforce key ' . $key . ' with the value of ' . $value, $this->text_domain ),
+					sprintf (
+						__( '%1$s: Comments: there are %2$s comment matches for the Salesforce key %3$s with the value of %4$s. Here they are: %5$s', $this->text_domain ),
+						ucfirst( $status ),
+						$count,
+						$key,
+						$value,
+						var_export( $comments )
+					),
 					'',
 					0,
 					0,
-					$status
+					'error'
 				);
 			} elseif ( false === $check_only ) {
 				// comment does not exist after checking the matching value. create it.
@@ -2283,7 +2289,7 @@ class Wordpress {
 				// comment does exist based on username, and we aren't doing a check only. we want to update the wp user here.
 				$comment_id = $existing_id;
 			}
-		} // End if().
+		} // End if() that sets up the parameters in the $params array.
 
 		if ( isset( $comment_id ) ) {
 			foreach ( $params as $key => $value ) {


### PR DESCRIPTION
## Changes

- In Wordpress::comment_upsert(), change 'notice' to 'error, because if, when creating/updating a WordPress comment, multiple WordPress comments exist for a given Salesforce ID, no comments will be updated.
- Change that error message to use `sprintf` so that we don't have to include a translation match for all possible combinations of status, count, key, value, and var_exported comments list.

## Why

If all comments for this Salesforce ID were updated, I would be in favor of it being a notice, but because nothing changes in the WordPress database, the comment upsert operation is failing to create or update any comments.

`var_export`ing the comments array so that they can be examined by someone reading the error log, so they can determine which/if to delete any of the comments.

Using sprintf because, as written, different values of `$count` would require different translations.