### PR TITLE
97 more zero id occurrences

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -766,4 +766,40 @@ class Object_Sync_Sf_Mapping {
 
 	}
 
+	/**
+	 * Check object map table to see if there have been any failed object map create attempts
+	 *
+	 * @return array $errors Associative array of rows that failed to finish from either system
+	 */
+	public function get_failed_object_maps() {
+		$table = $this->object_map_table;
+		$errors = array();
+		$push_errors = $this->wpdb->get_results( 'SELECT * FROM ' . $table . ' WHERE salesforce_id LIKE "tmp_sf_%"', ARRAY_A );
+		$pull_errors = $this->wpdb->get_results( 'SELECT * FROM ' . $table . ' WHERE wordpress_id LIKE "tmp_wp_%"', ARRAY_A );
+		if ( ! empty( $push_errors ) ) {
+			$errors['push_errors'] = $push_errors;
+		}
+		if ( ! empty( $pull_errors ) ) {
+			$errors['pull_errors'] = $pull_errors;
+		}
+		return $errors;
+	}
+
+	/**
+	 * Check object map table to see if there have been any failed object map create attempts
+	 *
+	 * @param int   $id The ID of a desired mapping.
+	 *
+	 * @return array $error Associative array of single row that failed to finish based on id
+	 */
+	public function get_failed_object_map( $id ) {
+		$table = $this->object_map_table;
+		$error = array();
+		$error_row = $this->wpdb->get_row( 'SELECT * FROM ' . $table . ' WHERE id = "' . $id . '"', ARRAY_A );
+		if ( ! empty( $error_row ) ) {
+			$error = $error_row;
+		}
+		return $error;
+	}
+
 }

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -507,10 +507,12 @@ class Object_Sync_Sf_Mapping {
 	 * Setup the data for the object map
 	 *
 	 * @param array $posted It's $_POST.
-	 * @return $data Literally returns the input of the function.
+	 * @return $data Filtered array with only the keys that are in the object map database table. Strips out things from WordPress form if they're present.
 	 */
 	private function setup_object_map_data( $posted = array() ) {
-		$data = $posted;
+		$allowed_fields = $this->wpdb->get_col( "DESC {$this->object_map_table}", 0 );
+		$allowed_fields[] = 'action'; // we use this in both directions even though it isn't in the database; we remove it from the array later if it is present
+		$data = array_intersect_key( $posted, array_flip( $allowed_fields ) );
 		return $data;
 	}
 

--- a/templates/admin/mapping-errors-delete.php
+++ b/templates/admin/mapping-errors-delete.php
@@ -1,0 +1,18 @@
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+	<input type="hidden" name="redirect_url_error" value="<?php echo esc_url( $error_url ); ?>" />
+	<input type="hidden" name="redirect_url_success" value="<?php echo esc_url( $success_url ); ?>" />
+	<input type="hidden" name="id" value="<?php echo absint( $map_row['id'] ); ?>" />
+	<input type="hidden" name="action" value="delete_object_map">
+	<h2><?php echo esc_html__( 'Are you sure you want to delete this mapping object?', 'object-sync-for-salesforce' ); ?></h2>
+	<p>
+	<?php
+		// translators: the placeholders refer to: 1) the WordPress object name, 2) the WordPress object Id, and 3) the Salesforce object Id
+		echo sprintf( esc_html__( 'This object map maps the WordPress %1$s with an id value of %2$s to the Salesforce object with Id of %3$s.', 'object-sync-for-salesforce' ),
+	    	'<strong> ' . esc_html( $map_row['wordpress_object'] ) . '</strong>',
+	    	'<strong> ' . esc_html( $map_row['wordpress_id'] ) . '</strong>',
+	    	'<strong> ' . esc_html( $map_row['salesforce_id'] ) . '</strong>'
+		);
+	?>
+	</p>
+	<?php submit_button( 'Confirm deletion' ); ?>
+</form>

--- a/templates/admin/mapping-errors-edit.php
+++ b/templates/admin/mapping-errors-edit.php
@@ -1,0 +1,21 @@
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="fieldmap">
+	<input type="hidden" name="redirect_url_error" value="<?php echo esc_url( $error_url ); ?>" />
+	<input type="hidden" name="redirect_url_success" value="<?php echo esc_url( $success_url ); ?>" />
+	<?php if ( isset( $transient ) ) { ?>
+	<input type="hidden" name="transient" value="<?php echo esc_html( $transient ); ?>" />
+	<?php } ?>
+	<input type="hidden" name="action" value="post_object_map" >
+	<input type="hidden" name="method" value="<?php echo esc_attr( $method ); ?>" />
+	<?php if ( 'edit' === $method ) { ?>
+	<input type="hidden" name="id" value="<?php echo absint( $map_row['id'] ); ?>" />
+	<?php } ?>
+	<div class="wordpress_id">
+		<label for="wordpress_id"><?php echo esc_html__( 'WordPress Id', 'object-sync-for-salesforce' ); ?>: </label>
+		<input type="text" id="wordpress_id" name="wordpress_id" required value="<?php echo isset( $wordpress_id ) ? esc_html( $wordpress_id ) : ''; ?>" />
+	</div>
+	<div class="salesforce_id">
+		<label for="salesforce_id"><?php echo esc_html__( 'Salesforce Id', 'object-sync-for-salesforce' ); ?>: </label>
+		<input type="text" id="salesforce_id" name="salesforce_id" required value="<?php echo isset( $salesforce_id ) ? esc_html( $salesforce_id ) : ''; ?>" />
+	</div>
+	<?php submit_button( ucfirst( $method ) . ' object map' ); ?>
+</form>

--- a/templates/admin/mapping-errors.php
+++ b/templates/admin/mapping-errors.php
@@ -1,0 +1,53 @@
+<h2><?php echo esc_html__( 'Mapping Errors', 'object-sync-for-salesforce' ); ?></h2>
+<p><?php echo esc_html__( 'When this tab is present, it means one or more mapping errors have occurred when the plugin has tried to save a new mapping object, either based on data pulled in from Salesforce or data that was sent to Salesforce. The plugin creates a temporary flag for WordPress (if it is a pull action) or for Salesforce (if it is a push action), and if it fails the temporary flag remains.', 'object-sync-for-salesforce' ); ?></p>
+<p><?php echo esc_html__( 'For any mapping object error, you can edit (if, for example, you know the ID of the item that should be in place) or delete each database row, or you can try to track down what the plugin was doing based on the other data displayed here.', 'object-sync-for-salesforce' ); ?></p>
+<p><?php echo esc_html__( 'If you edit one of these items, and it correctly maps data between the two systems, the sync for those items will behave as normal going forward, so any edits you do after that will sync as they should.', 'object-sync-for-salesforce' ); ?></p>
+
+<table class="widefat striped">
+	<thead>
+		<tr>
+			<th><?php echo esc_html__( 'Type', 'object-sync-for-salesforce' ); ?></th>
+			<th><?php echo esc_html__( 'WordPress ID', 'object-sync-for-salesforce' ); ?></th>
+			<th><?php echo esc_html__( 'WordPress Object Type', 'object-sync-for-salesforce' ); ?></th>
+			<th><?php echo esc_html__( 'Salesforce ID', 'object-sync-for-salesforce' ); ?></th>
+			<th><?php echo esc_html__( 'Created Date/Time', 'object-sync-for-salesforce' ); ?></th>
+			<th colspan="2"><?php echo esc_html__( 'Actions', 'object-sync-for-salesforce' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+		<?php if ( ! empty( $mapping_errors['pull_errors'] ) ) : ?>
+			<?php foreach ( $mapping_errors['pull_errors'] as $error ) { ?>
+		<tr>
+			<td><?php echo esc_html__( 'Pull from Salesforce', 'object-sync-for-salesforce' ); ?></td>
+			<td><?php echo $error['wordpress_id'] ?></td>
+			<td><?php echo $error['wordpress_object'] ?></td>
+			<td><?php echo $error['salesforce_id'] ?></td>
+			<td><?php echo date_i18n( 'Y-m-d g:i:sa', strtotime( $error['created'] ) ); ?></td>
+			<td>
+				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>
+			</td>
+			<td>
+				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
+			</td>
+		</tr>
+			<?php } ?>
+		<?php endif; ?>
+		<?php if ( ! empty( $mapping_errors['push_errors'] ) ) : ?>
+			<?php foreach ( $mapping_errors['push_errors'] as $error ) { ?>
+		<tr>
+			<td><?php echo esc_html__( 'Push to Salesforce', 'object-sync-for-salesforce' ); ?></td>
+			<td><?php echo $error['wordpress_id'] ?></td>
+			<td><?php echo $error['wordpress_object'] ?></td>
+			<td><?php echo $error['salesforce_id'] ?></td>
+			<td><?php echo date_i18n( 'Y-m-d g:i:sa', strtotime( $error['created'] ) ); ?></td>
+			<td>
+				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>
+			</td>
+			<td>
+				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
+			</td>
+		</tr>
+			<?php } ?>
+		<?php endif; ?>
+	</tbody>
+</table>


### PR DESCRIPTION
This builds a basic interface for object map rows that failed to be fully created to map objects between the two systems, and have a temporary ID for either WordPress or Salesforce.

If any of these rows are present in the database, it creates a Mapping Errors tab at `/wp-admin/options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors`.

For each row, it shows the WordPress ID, WordPress object type, Salesforce ID, and when it was created. Users are able to edit each row's WordPress and/or Salesforce ID, in case the data they need to map does actually exist, and are also able to delete each row individually in case they just want to let the plugin run again.

This should further solve the issues raised in #97, as it gives users a non SQL way to manage those error rows, on top of the previous PR on this branch that kept them from preventing further syncing.

Noteworthy change: in `salesforce_mapping` we now filter the `$posted` array so it only contains the columns in the database table for object maps, plus the `action` parameter that we filter out later. I've verified that the various `create_object_map` methods do not contain other parameters that we need to preserve for similar use to the `action`.