### PR TITLE
Check both insert & update to support creating a new WP post from a modified SF object

### DIFF
--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -1083,8 +1083,11 @@ class Object_Sync_Sf_WordPress {
 	 *   "errors" : [ ],
 	 */
 	private function post_create( $params, $id_field = 'ID', $post_type = '' ) {
+		$content = array();
+
 		foreach ( $params as $key => $value ) {
-			if ( 'wp_insert_post' === $value['method_modify'] ) {
+			// Check both insert & update to support creating a new WP post from a modified SF object
+			if ( 'wp_insert_post' === $value['method_modify'] || 'wp_update_post' === $value['method_modify'] ) {
 				$content[ $key ] = $value['value'];
 				unset( $params[ $key ] );
 			}

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -1082,12 +1082,12 @@ class Object_Sync_Sf_WordPress {
 	 *     success: 1
 	 *   "errors" : [ ],
 	 */
-	private function post_create( $params, $id_field = 'ID', $post_type = '' ) {
+	private function post_create( $params, $id_field = 'ID', $post_type = 'post' ) {
+		// Load all params with a method_modify of the object structure's content_method into $content
 		$content = array();
-
+		$structure = get_wordpress_table_structure( $post_type );
 		foreach ( $params as $key => $value ) {
-			// Check both insert & update to support creating a new WP post from a modified SF object
-			if ( 'wp_insert_post' === $value['method_modify'] || 'wp_update_post' === $value['method_modify'] ) {
+			if ( in_array( $value['method_modify'], $structure['content_methods'] ) ) {
 				$content[ $key ] = $value['value'];
 				unset( $params[ $key ] );
 			}


### PR DESCRIPTION
See #115

Resolves issue where creating a new WordPress post from a modified existing SF Object loses all content fields, which have the method_modify wp_update_post rather than the expected wp_insert_post.