### PR TITLE
115 do not create blank posts if not allowed

### DIFF
--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -214,6 +214,25 @@ class Object_Sync_Sf_Salesforce_Pull {
 							'sf_sync_trigger' => $sf_sync_trigger, // use the appropriate trigger based on when this was created
 						);
 
+						// Hook to allow other plugins to prevent a pull per-mapping.
+						// Putting the pull_allowed hook here will keep the queue from storing data when it is not supposed to store it
+						$pull_allowed = apply_filters( 'object_sync_for_salesforce_pull_object_allowed', true, $type, $result, $sf_sync_trigger, $salesforce_mapping );
+
+						// example to keep from pulling the Contact with id of abcdef
+						/*
+						add_filter( 'object_sync_for_salesforce_pull_object_allowed', 'check_user', 10, 5 );
+						// can always reduce this number if all the arguments are not necessary
+						function check_user( $pull_allowed, $object_type, $object, $sf_sync_trigger, $salesforce_mapping ) {
+							if ( $object_type === 'Contact' && $object['Id'] === 'abcdef' ) {
+								return false;
+							}
+						}
+						*/
+
+						if ( false === $pull_allowed ) {
+							continue;
+						}
+
 						// Initialize the queue with the data for this record and save
 						$this->schedule->data( array( $data ) );
 						$this->schedule->save()->dispatch();
@@ -545,24 +564,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$status
 				);
 				return;
-			}
-
-			// hook to allow other plugins to prevent a pull per-mapping.
-			$pull_allowed = apply_filters( 'object_sync_for_salesforce_pull_object_allowed', true, $object_type, $object, $sf_sync_trigger, $salesforce_mapping );
-
-			// example to keep from pulling the Contact with id of abcdef
-			/*
-			add_filter( 'object_sync_for_salesforce_pull_object_allowed', 'check_user', 10, 5 );
-			// can always reduce this number if all the arguments are not necessary
-			function check_user( $pull_allowed, $object_type, $object, $sf_sync_trigger, $salesforce_mapping ) {
-				if ( $object_type === 'Contact' && $object['Id'] === 'abcdef' ) {
-					return false;
-				}
-			}
-			*/
-
-			if ( false === $pull_allowed ) {
-				continue;
 			}
 
 			// if there's already a connection between the objects, $mapping_object will be an array


### PR DESCRIPTION
What this does is remove the `pull_allowed` flag, and the hooks that can modify it, from the `salesforce_pull_process_records()` method, which runs **after** the queue has been populated. Instead, it puts it inside the `get_updated_records()` and `get_deleted_records()` methods, which run **before** the queue is populated.

This should achieve these things:

1. Deal with the issue in #115 where blank `post` records can be created, if the `pull_allowed` status changes. This is currently happening because those records exist in the queue.
2. Not add stuff to the queue if its `pull_allowed` status is false.