### PR TITLE
129 delete data on uninstall option

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -538,6 +538,18 @@ class Object_Sync_Sf_Admin {
 					'constant' => '',
 				),
 			),
+			'delete_data_on_uninstall' => array(
+				'title' => 'Delete plugin data on uninstall?',
+				'callback' => $callbacks['text'],
+				'page' => $page,
+				'section' => $section,
+				'args' => array(
+					'type' => 'checkbox',
+					'validate' => 'sanitize_text_field',
+					'desc' => 'If checked, the plugin will delete the tables and other data it creates when you uninstall it. Unchecking this field can be useful if you need to reactivate the plugin for any reason without losing data.',
+					'constant' => '',
+				),
+			),
 		);
 
 		if ( true === is_object( $this->salesforce['sfapi'] ) && true === $this->salesforce['sfapi']->is_authorized() ) {

--- a/classes/deactivate.php
+++ b/classes/deactivate.php
@@ -113,7 +113,7 @@ class Object_Sync_Sf_Deactivate {
 	*
 	*/
 	public function delete_plugin_options() {
-		$plugin_options = $wpdb->get_results( "SELECT option_name FROM $wpdb->options WHERE option_name LIKE 'object_sync_for_salesforce_%'" );
+		$plugin_options = $this->wpdb->get_results( "SELECT option_name FROM $this->wpdb->options WHERE option_name LIKE 'object_sync_for_salesforce_%'" );
 		foreach ( $plugin_options as $option ) {
 			delete_option( $option->option_name );
 		}

--- a/classes/deactivate.php
+++ b/classes/deactivate.php
@@ -113,9 +113,10 @@ class Object_Sync_Sf_Deactivate {
 	*
 	*/
 	public function delete_plugin_options() {
-		$plugin_options = $this->wpdb->get_results( "SELECT option_name FROM $this->wpdb->options WHERE option_name LIKE 'object_sync_for_salesforce_%'" );
+		$table = $this->wpdb->prefix . 'options';
+		$plugin_options = $this->wpdb->get_results( 'SELECT option_name FROM ' . $table . ' WHERE option_name LIKE "object_sync_for_salesforce_%"', ARRAY_A );
 		foreach ( $plugin_options as $option ) {
-			delete_option( $option->option_name );
+			delete_option( $option['option_name'] );
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

This fixes #129 by adding a checkbox to the Settings tab for deleting the plugin's data when it is uninstalled. It is not checked by default, but if it is checked it deletes the following things when the plugin is uninstalled:

1. The `object_sync_sf_field_map` and `object_sync_sf_object_map` database tables
2. Any scheduled tasks this plugin may have pending
3. The `wp_log` post type
4. The `configure_salesforce` capability. It also removes this capability from any roles that had it.
5. Any cached content related to this plugin
6. Any items in the `options` table that start with `object_sync_for_salesforce_`

## How do I test this PR?

- Install the plugin
- Save either value for the option
- Make sure it works as it should (either it should delete all the above data, or none of it)
