### PR TITLE
Stop setting pull last sync timestamp after pull record processing completes

### DIFF
--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -288,9 +288,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					$next_records_url = isset( $new_response['nextRecordsUrl'] ) ? str_replace( $version_path, '', $new_response['nextRecordsUrl'] ) : false;
 				}
-
-				update_option( 'object_sync_for_salesforce_pull_last_sync_' . $type, current_time( 'timestamp', true ) );
-
 			} else {
 
 				// create log entry for failed pull


### PR DESCRIPTION
Fixes #137

Setting the `'object_sync_for_salesforce_pull_last_sync_' . $type` timestamp after pull processing completes causes the sync to miss any SF changes that occurred after the sync query, while it processed records.

To resolve #113, the pull sync began also setting the last sync timestamp to the most recently processed record's pull_trigger_field value. Using those exclusively will resolve the race condition described in issue #137.

## What does this PR do?

## How do I test this PR?

- click a button
- view the cat
- see the cat meow
