### PR TITLE
fix for 142

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -329,6 +329,7 @@ class Object_Sync_Sf_Mapping {
 						'wordpress_field' => array(
 							'label' => sanitize_text_field( $posted['wordpress_field'][ $key ] ),
 							'methods' => maybe_unserialize( $wordpress_fields[ $method_key ]['methods'] ),
+							'type' => sanitize_text_field( $wordpress_fields[ $method_key ]['type'] ),
 						),
 						'salesforce_field' => $salesforce_field_attributes,
 						'is_prematch' => sanitize_text_field( $posted['is_prematch'][ $key ] ),
@@ -777,6 +778,9 @@ class Object_Sync_Sf_Mapping {
 					switch ( $salesforce_field_type ) {
 						case ( in_array( $salesforce_field_type, $this->date_types_from_salesforce ) ):
 							$format = get_option( 'date_format', 'U' );
+							if ( isset( $fieldmap['wordpress_field']['type'] ) && 'datetime' === $fieldmap['wordpress_field']['type'] ) {
+								$format = 'Y-m-d H:i:s';
+							}
 							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $object[ $salesforce_field ] ) );
 							break;
 						case ( in_array( $salesforce_field_type, $this->int_types_from_salesforce ) ):

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -440,6 +440,7 @@ class Object_Sync_Sf_WordPress {
 		// Maybe a box for a custom query, since custom fields get done in so many ways.
 		// Eventually this would be the kind of thing we could use fields api for, if it ever gets done.
 		$data_fields = $this->wpdb->get_col( "DESC {$content_table}", 0 );
+		$data_field_types = $this->wpdb->get_col( "DESC {$content_table}", 1 ); // get the database field types
 
 		if ( is_array( $meta_table ) ) {
 			$tax_table = $meta_table[1];
@@ -463,6 +464,7 @@ class Object_Sync_Sf_WordPress {
 					'key' => $value,
 					'table' => $content_table,
 					'methods' => serialize( $content_methods ),
+					'type' => $data_field_types[ $key ],
 				);
 			}
 		}


### PR DESCRIPTION
## What does this PR do?

This provides a fix for #142. If a fieldmap is resaved, it will cause any dates coming from Salesforce that match core Wordpress date fields (ie post_date, post_modified, user_registered, etc.) to be used in the format WordPress expects.

## How do I test this PR?

1. Clear the plugin cache
2. Save a fieldmap that maps a Salesforce date field to one of the core WordPress date fields
3. Create or update data in Salesforce that matches this map. The data should be correctly saved in WordPress.