### PR TITLE
Update extending-wordpress.md

### DIFF
--- a/docs/extending-wordpress.md
+++ b/docs/extending-wordpress.md
@@ -106,7 +106,7 @@ Developers can use the `object_sync_for_salesforce_upsert_custom_wordpress_item`
 #### Code example
 
 ```
-add_filter( 'object_sync_for_salesforce_upsert_custom_wordpress_item', add_object, 10, 1 );
+add_filter( 'object_sync_for_salesforce_upsert_custom_wordpress_item', upsert_object, 10, 1 );
 function upsert_object( $create_data ) {
     /* $upsert_data is like this:
     array(


### PR DESCRIPTION
On the first block of example for upsert, shouldn't the second parameter for `add_filter` be `upsert_object` ?


