### PR TITLE
158 fix email field fails when creating new user from salesforce update

### DIFF
--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -831,7 +831,8 @@ class Object_Sync_Sf_WordPress {
 				'method_modify' => 'wp_insert_user',
 				'method_read'   => 'get_user_by',
 			);
-
+			// Load all params with a method_modify of the object structure's content_method into $content
+			$content   = array();
 			$structure = $this->get_wordpress_table_structure( 'user' );
 			foreach ( $params as $key => $value ) {
 				if ( in_array( $value['method_modify'], $structure['content_methods'] ) ) {

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -833,7 +833,7 @@ class Object_Sync_Sf_WordPress {
 			);
 
 			foreach ( $params as $key => $value ) {
-				if ( 'wp_insert_user' === $value['method_modify'] ) {
+				if ( 'wp_insert_user' === $value['method_modify'] || 'wp_update_user' === $value['method_modify'] ) {
 					$content[ $key ] = $value['value'];
 					unset( $params[ $key ] );
 				}

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -832,8 +832,9 @@ class Object_Sync_Sf_WordPress {
 				'method_read'   => 'get_user_by',
 			);
 
+			$structure = $this->get_wordpress_table_structure( 'user' );
 			foreach ( $params as $key => $value ) {
-				if ( 'wp_insert_user' === $value['method_modify'] || 'wp_update_user' === $value['method_modify'] ) {
+				if ( in_array( $value['method_modify'], $structure['content_methods'] ) ) {
 					$content[ $key ] = $value['value'];
 					unset( $params[ $key ] );
 				}


### PR DESCRIPTION
## What does this PR do?

This addresses the issue in #158 where a modified Salesforce Contact, which is not mapped to a user in WordPress but when the fieldmap does exist, would try to create a new user in WordPress but fail to add the email address to the email field.

This PR surprisingly just makes the `user_create` method behave more similarly to `post_create` with how it creates the array of content from the Salesforce data. I think this makes it less risky, and it may have just been overlooked previously.

## How do I test this PR?

The reported issue can be tested like this:

1. Find a Contact that exists in Salesforce, but is not mapped to a user in WordPress.
2. Update that Contact in Salesforce.
3. The plugin should create a new user in WordPress.
4. Make sure the new user has all the data it should have, especially the email address.

However we need to do some additional testing just to make sure the change doesn't do anything weird.