### PR TITLE
157 stop prematch and key from requiring updateable

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -768,7 +768,8 @@ class Object_Sync_Sf_Mapping {
 					);
 				}
 
-				// Skip fields that aren't updateable when mapping params because Salesforce will error otherwise. This happens after dealing with the field types because key and prematch should still be available to the plugin, even if the values are not updateable in Salesforce.
+				// Skip fields that aren't updateable when mapping params because Salesforce will error otherwise.
+				// This happens after dealing with the field types because key and prematch should still be available to the plugin, even if the values are not updateable in Salesforce.
 				if ( 1 !== (int) $fieldmap['salesforce_field']['updateable'] ) {
 					continue;
 				}

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -312,7 +312,7 @@ class Object_Sync_Sf_Mapping {
 					$posted['is_delete'][ $key ] = false;
 				}
 				if ( false === $posted['is_delete'][ $key ] ) {
-
+					// I think it's good to over-mention that updateable is really how the Salesforce api spells it, even though that is wrong.
 					$updateable_key = array_search( $posted['salesforce_field'][ $key ], array_column( $salesforce_fields, 'name' ), true );
 
 					$salesforce_field_attributes = array();
@@ -768,6 +768,7 @@ class Object_Sync_Sf_Mapping {
 					);
 				}
 
+				// I think it's good to over-mention that updateable is really how the Salesforce api spells it, even though that is wrong.
 				// Skip fields that aren't updateable when mapping params because Salesforce will error otherwise.
 				// This happens after dealing with the field types because key and prematch should still be available to the plugin, even if the values are not updateable in Salesforce.
 				if ( 1 !== (int) $fieldmap['salesforce_field']['updateable'] ) {

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -312,7 +312,7 @@ class Object_Sync_Sf_Mapping {
 					$posted['is_delete'][ $key ] = false;
 				}
 				if ( false === $posted['is_delete'][ $key ] ) {
-					// I think it's good to over-mention that updateable is really how the Salesforce api spells it, even though that is wrong.
+					// I think it's good to over-mention that updateable is really how the Salesforce api spells it.
 					$updateable_key = array_search( $posted['salesforce_field'][ $key ], array_column( $salesforce_fields, 'name' ), true );
 
 					$salesforce_field_attributes = array();
@@ -768,11 +768,11 @@ class Object_Sync_Sf_Mapping {
 					);
 				}
 
-				// I think it's good to over-mention that updateable is really how the Salesforce api spells it, even though that is wrong.
+				// I think it's good to over-mention that updateable is really how the Salesforce api spells it.
 				// Skip fields that aren't updateable when mapping params because Salesforce will error otherwise.
 				// This happens after dealing with the field types because key and prematch should still be available to the plugin, even if the values are not updateable in Salesforce.
 				if ( 1 !== (int) $fieldmap['salesforce_field']['updateable'] ) {
-					continue;
+					unset( $params[ $salesforce_field ] );
 				}
 			} elseif ( in_array( $trigger, $salesforce_haystack, true ) ) {
 

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -688,6 +688,7 @@ class Object_Sync_Sf_Mapping {
 
 			$fieldmap['wordpress_field']['methods'] = maybe_unserialize( $fieldmap['wordpress_field']['methods'] );
 
+			// todo: we should think about whether this needs to be moved to after the key/prematching?
 			// skip fields that aren't being pushed to Salesforce.
 			if ( in_array( $trigger, $wordpress_haystack, true ) && ! in_array( $fieldmap['direction'], array_values( $this->direction_wordpress ), true ) ) {
 				// The trigger is a WordPress trigger, but the fieldmap direction is not a WordPress direction.

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -688,19 +688,6 @@ class Object_Sync_Sf_Mapping {
 
 			$fieldmap['wordpress_field']['methods'] = maybe_unserialize( $fieldmap['wordpress_field']['methods'] );
 
-			// todo: we should think about whether this needs to be moved to after the key/prematching?
-			// skip fields that aren't being pushed to Salesforce.
-			if ( in_array( $trigger, $wordpress_haystack, true ) && ! in_array( $fieldmap['direction'], array_values( $this->direction_wordpress ), true ) ) {
-				// The trigger is a WordPress trigger, but the fieldmap direction is not a WordPress direction.
-				continue;
-			}
-
-			// skip fields that aren't being pulled from Salesforce.
-			if ( in_array( $trigger, $salesforce_haystack, true ) && ! in_array( $fieldmap['direction'], array_values( $this->direction_salesforce ), true ) ) {
-				// The trigger is a Salesforce trigger, but the fieldmap direction is not a Salesforce direction.
-				continue;
-			}
-
 			$wordpress_field = $fieldmap['wordpress_field']['label'];
 
 			if ( version_compare( $this->version, '1.2.0', '>=' ) && isset( $fieldmap['salesforce_field']['name'] ) ) {
@@ -767,6 +754,12 @@ class Object_Sync_Sf_Mapping {
 						'wordpress_field'  => $wordpress_field,
 						'value'            => $object[ $wordpress_field ],
 					);
+				}
+
+				// Skip fields that aren't being pushed to Salesforce.
+				if ( ! in_array( $fieldmap['direction'], array_values( $this->direction_wordpress ), true ) ) {
+					// The trigger is a WordPress trigger, but the fieldmap direction is not a WordPress direction.
+					unset( $params[ $salesforce_field ] );
 				}
 
 				// I think it's good to over-mention that updateable is really how the Salesforce api spells it.
@@ -838,6 +831,12 @@ class Object_Sync_Sf_Mapping {
 						'method_create'    => $fieldmap['wordpress_field']['methods']['create'],
 						'method_update'    => $fieldmap['wordpress_field']['methods']['update'],
 					);
+				}
+
+				// Skip fields that aren't being pulled from Salesforce.
+				if ( ! in_array( $fieldmap['direction'], array_values( $this->direction_salesforce ), true ) ) {
+					// The trigger is a Salesforce trigger, but the fieldmap direction is not a Salesforce direction.
+					unset( $params[ $wordpress_field ] );
 				}
 
 				switch ( $trigger ) {

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -713,11 +713,6 @@ class Object_Sync_Sf_Mapping {
 			// A WordPress event caused this.
 			if ( in_array( $trigger, array_values( $wordpress_haystack ), true ) ) {
 
-				// Skip fields that aren't updateable when mapping params because Salesforce will error otherwise.
-				if ( 1 !== (int) $fieldmap['salesforce_field']['updateable'] ) {
-					continue;
-				}
-
 				// Is the field in WordPress an array, if we unserialize it? Salesforce wants it to be an imploded string.
 				if ( is_array( maybe_unserialize( $object[ $wordpress_field ] ) ) ) {
 					$object[ $wordpress_field ] = implode( $this->array_delimiter, $object[ $wordpress_field ] );
@@ -771,6 +766,11 @@ class Object_Sync_Sf_Mapping {
 						'wordpress_field'  => $wordpress_field,
 						'value'            => $object[ $wordpress_field ],
 					);
+				}
+
+				// Skip fields that aren't updateable when mapping params because Salesforce will error otherwise. This happens after dealing with the field types because key and prematch should still be available to the plugin, even if the values are not updateable in Salesforce.
+				if ( 1 !== (int) $fieldmap['salesforce_field']['updateable'] ) {
+					continue;
 				}
 			} elseif ( in_array( $trigger, $salesforce_haystack, true ) ) {
 


### PR DESCRIPTION
## What does this PR do?

This fixes the issue where the key and prematch fields are ignored if their Salesforce status is not updateable, which breaks prematch.

## How do I test this PR?

- Create a new Contact in Salesforce
- Create a new user in WordPress
- Add a meta value to that user containing the Contact ID (field name: Id) from the new user in Salesforce
- Create a mapping for Users to Contacts with that meta key mapping to Contact ID, and some other fields mapped as well (just to be able to see the results), with at least WordPress update as a trigger. Make sure the meta->Contact ID fieldmap is marked as prematch and/or key and no other fields are marked as prematch or key
- Change the user's name

Instead of creating a new Contact in Salesforce, it should use the meta to perform an upsert on the existing and correct Contact record.