### PR TITLE
removed curly brackets from add_action save_post_$object_type

### DIFF
--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -90,7 +90,7 @@ class Object_Sync_Sf_Salesforce_Push {
 					add_action( 'edit_comment', array( $this, 'edit_comment' ) );
 					add_action( 'delete_comment', array( $this, 'delete_comment' ) ); // to be clear: this only runs when the comment gets deleted from the trash, either manually or automatically
 				} else { // this is for custom post types
-					add_action( 'save_post_{' . $object_type . '}', array( $this, 'post_actions' ), 11, 2 );
+					add_action( 'save_post_' . $object_type, array( $this, 'post_actions' ), 11, 2 );
 				}
 			}
 		}


### PR DESCRIPTION
For custom post types, the save_post_$object_type action does not use curly brackets.

## What does this PR do?
fix issue where filter not executed when custom post type is updated/created

## How do I test this PR?
save a custom post type, see if it pushes to salesforce
