### PR TITLE
Don't coerce NULL values coming from Salesforce into other data types

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -774,7 +774,7 @@ class Object_Sync_Sf_Mapping {
 
 				// A Salesforce event caused this.
 
-				if ( isset( $salesforce_field_type ) ) {
+				if ( isset( $salesforce_field_type ) && ! is_null( $object[ $salesforce_field ] ) ) {
 					// Salesforce provides multipicklist values as a delimited string. If the
 					// destination field in WordPress accepts multiple values, explode the string into an array and then serialize it.
 					if ( in_array( $salesforce_field_type, $this->array_types_from_salesforce ) ) {


### PR DESCRIPTION
## What does this PR do?

Addresses #186 by bypassing the code that reformats a Salesforce field's value based on the field's data type when the value is NULL.

## How do I test this PR?

- Create a Salesforce setup that includes non-required date, int, text, and URL fields.
- Pull a record from Salesforce to WP for which those fields are empty or NULL.
- Confirm that they're all stored as NULLs in the WordPress database.