### PR TITLE
Delete multiple object map error rows

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1102,31 +1102,31 @@ class Object_Sync_Sf_Admin {
 		require_once plugin_dir_path( __FILE__ ) . '../classes/admin-notice.php';
 
 		$notices = array(
-			'permission'      => array(
+			'permission'              => array(
 				'condition'   => false === $this->check_wordpress_admin_permissions(),
 				'message'     => __( "Your account does not have permission to edit the Salesforce REST API plugin's settings.", 'object-sync-for-salesforce' ),
 				'type'        => 'error',
 				'dismissible' => false,
 			),
-			'fieldmap'        => array(
+			'fieldmap'                => array(
 				'condition'   => isset( $get_data['transient'] ),
 				'message'     => __( 'Errors kept this fieldmap from being saved.', 'object-sync-for-salesforce' ),
 				'type'        => 'error',
 				'dismissible' => true,
 			),
-			'object_map'      => array(
+			'object_map'              => array(
 				'condition'   => isset( $get_data['map_transient'] ),
 				'message'     => __( 'Errors kept this object map from being saved.', 'object-sync-for-salesforce' ),
 				'type'        => 'error',
 				'dismissible' => true,
 			),
-			'data_saved'      => array(
+			'data_saved'              => array(
 				'condition'   => isset( $get_data['data_saved'] ) && 'true' === $get_data['data_saved'],
 				'message'     => __( 'This data was successfully saved.', 'object-sync-for-salesforce' ),
 				'type'        => 'success',
 				'dismissible' => true,
 			),
-			'data_save_error' => array(
+			'data_save_error'         => array(
 				'condition'   => isset( $get_data['data_saved'] ) && 'false' === $get_data['data_saved'],
 				'message'     => __( 'This data was not successfully saved. Try again.', 'object-sync-for-salesforce' ),
 				'type'        => 'error',

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -397,7 +397,7 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Delete a fieldmap row between a WordPress and Salesforce object
 	 *
-	 * @param array $id The ID of a field mapping.
+	 * @param int $id The ID of a field mapping.
 	 * @return Boolean
 	 * @throws \Exception
 	 */
@@ -565,18 +565,28 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Delete an object map row between a WordPress and Salesforce object
 	 *
-	 * @param array $id The ID of the object map row.
+	 * @param int|array $id The ID or IDs of the object map row(s).
 	 * @throws \Exception
 	 */
 	public function delete_object_map( $id = '' ) {
-		$data   = array(
-			'id' => $id,
-		);
-		$delete = $this->wpdb->delete( $this->object_map_table, $data );
-		if ( 1 === $delete ) {
-			return true;
-		} else {
-			return false;
+		if ( is_int( $id ) ) {
+			$data   = array(
+				'id' => $id,
+			);
+			$delete = $this->wpdb->delete( $this->object_map_table, $data );
+			if ( 1 === $delete ) {
+				return true;
+			} else {
+				return false;
+			}
+		} elseif ( is_array( $id ) ) {
+			$ids    = implode( ',', array_map( 'absint', $id ) );
+			$delete = $this->wpdb->query( "DELETE FROM $this->object_map_table WHERE ID IN ($ids)" );
+			if ( false !== $delete ) {
+				return true;
+			} else {
+				return false;
+			}
 		}
 	}
 

--- a/templates/admin/mapping-errors.php
+++ b/templates/admin/mapping-errors.php
@@ -3,51 +3,87 @@
 <p><?php echo esc_html__( 'For any mapping object error, you can edit (if, for example, you know the ID of the item that should be in place) or delete each database row, or you can try to track down what the plugin was doing based on the other data displayed here.', 'object-sync-for-salesforce' ); ?></p>
 <p><?php echo esc_html__( 'If you edit one of these items, and it correctly maps data between the two systems, the sync for those items will behave as normal going forward, so any edits you do after that will sync as they should.', 'object-sync-for-salesforce' ); ?></p>
 
-<table class="widefat striped">
-	<thead>
-		<tr>
-			<th><?php echo esc_html__( 'Type', 'object-sync-for-salesforce' ); ?></th>
-			<th><?php echo esc_html__( 'WordPress ID', 'object-sync-for-salesforce' ); ?></th>
-			<th><?php echo esc_html__( 'WordPress Object Type', 'object-sync-for-salesforce' ); ?></th>
-			<th><?php echo esc_html__( 'Salesforce ID', 'object-sync-for-salesforce' ); ?></th>
-			<th><?php echo esc_html__( 'Created Date/Time', 'object-sync-for-salesforce' ); ?></th>
-			<th colspan="2"><?php echo esc_html__( 'Actions', 'object-sync-for-salesforce' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php if ( ! empty( $mapping_errors['pull_errors'] ) ) : ?>
-			<?php foreach ( $mapping_errors['pull_errors'] as $error ) { ?>
-		<tr>
-			<td><?php echo esc_html__( 'Pull from Salesforce', 'object-sync-for-salesforce' ); ?></td>
-			<td><?php echo $error['wordpress_id']; ?></td>
-			<td><?php echo $error['wordpress_object']; ?></td>
-			<td><?php echo $error['salesforce_id']; ?></td>
-			<td><?php echo date_i18n( 'Y-m-d g:i:sa', strtotime( $error['created'] ) ); ?></td>
-			<td>
-				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>
-			</td>
-			<td>
-				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
-			</td>
-		</tr>
-			<?php } ?>
-		<?php endif; ?>
-		<?php if ( ! empty( $mapping_errors['push_errors'] ) ) : ?>
-			<?php foreach ( $mapping_errors['push_errors'] as $error ) { ?>
-		<tr>
-			<td><?php echo esc_html__( 'Push to Salesforce', 'object-sync-for-salesforce' ); ?></td>
-			<td><?php echo $error['wordpress_id']; ?></td>
-			<td><?php echo $error['wordpress_object']; ?></td>
-			<td><?php echo $error['salesforce_id']; ?></td>
-			<td><?php echo date_i18n( 'Y-m-d g:i:sa', strtotime( $error['created'] ) ); ?></td>
-			<td>
-				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>
-			</td>
-			<td>
-				<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
-			</td>
-		</tr>
-			<?php } ?>
-		<?php endif; ?>
-	</tbody>
-</table>
+<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="error-rows">
+	<input type="hidden" name="redirect_url_error" value="<?php echo esc_url( $error_url ); ?>">
+	<input type="hidden" name="redirect_url_success" value="<?php echo esc_url( $success_url ); ?>">
+	<input type="hidden" name="action" value="delete_object_map">
+	<?php if ( isset( $mapping_error_transient ) ) { ?>
+	<input type="hidden" name="mapping_error_transient" value="<?php echo esc_html( $mapping_error_transient ); ?>">
+	<?php } ?>
+	<table class="widefat striped">
+		<thead>
+			<tr>
+				<th>&nbsp;</th>
+				<th><?php echo esc_html__( 'Type', 'object-sync-for-salesforce' ); ?></th>
+				<th><?php echo esc_html__( 'WordPress ID', 'object-sync-for-salesforce' ); ?></th>
+				<th><?php echo esc_html__( 'WordPress Object Type', 'object-sync-for-salesforce' ); ?></th>
+				<th><?php echo esc_html__( 'Salesforce ID', 'object-sync-for-salesforce' ); ?></th>
+				<th><?php echo esc_html__( 'Created Date/Time', 'object-sync-for-salesforce' ); ?></th>
+				<th colspan="2"><?php echo esc_html__( 'Actions', 'object-sync-for-salesforce' ); ?></th>
+			</tr>
+		</thead>
+		<tfoot>
+			<tr>
+				<td colspan="8">
+					<?php
+						submit_button(
+							esc_html__( 'Delete selected rows', 'object-sync-for-salesforce' )
+						);
+						?>
+				</td>
+			</tr>
+		</tfoot>
+		<tbody>
+			<?php if ( ! empty( $mapping_errors['pull_errors'] ) ) : ?>
+				<?php foreach ( $mapping_errors['pull_errors'] as $error ) { ?>
+			<tr>
+					<?php
+					if ( in_array( $error['id'], $ids ) ) {
+						$checked = ' checked';
+					} else {
+						$checked = '';
+					}
+					?>
+				<td><input type="checkbox" name="delete[<?php echo $error['id']; ?>]" id="delete_<?php echo $error['id']; ?>"<?php echo $checked; ?>></td>
+				<td><?php echo esc_html__( 'Pull from Salesforce', 'object-sync-for-salesforce' ); ?></td>
+				<td><?php echo $error['wordpress_id']; ?></td>
+				<td><?php echo $error['wordpress_object']; ?></td>
+				<td><?php echo $error['salesforce_id']; ?></td>
+				<td><?php echo date_i18n( 'Y-m-d g:i:sa', strtotime( $error['created'] ) ); ?></td>
+				<td>
+					<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>
+				</td>
+				<td>
+					<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
+				</td>
+			</tr>
+				<?php } ?>
+			<?php endif; ?>
+			<?php if ( ! empty( $mapping_errors['push_errors'] ) ) : ?>
+				<?php foreach ( $mapping_errors['push_errors'] as $error ) { ?>
+			<tr>
+					<?php
+					if ( is_array( array_keys( $ids ) ) && in_array( $error['id'], array_keys( $ids ) ) ) {
+						$checked = ' checked';
+					} else {
+						$checked = '';
+					}
+					?>
+				<td><input type="checkbox" name="delete[<?php echo $error['id']; ?>]" id="delete_<?php echo $error['id']; ?>"<?php echo $checked; ?>></td>
+				<td><?php echo esc_html__( 'Push to Salesforce', 'object-sync-for-salesforce' ); ?></td>
+				<td><?php echo $error['wordpress_id']; ?></td>
+				<td><?php echo $error['wordpress_object']; ?></td>
+				<td><?php echo $error['salesforce_id']; ?></td>
+				<td><?php echo date_i18n( 'Y-m-d g:i:sa', strtotime( $error['created'] ) ); ?></td>
+				<td>
+					<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>
+				</td>
+				<td>
+					<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
+				</td>
+			</tr>
+				<?php } ?>
+			<?php endif; ?>
+		</tbody>
+	</table>
+</form>


### PR DESCRIPTION
## What does this PR do?

This provides checkboxes and a form to delete multiple object maps from the Mapping Errors tab of the admin interface. As such, it fixes #165.

## How do I test this PR?

- get some errors
- delete them via the checkboxes.