### PR TITLE
212 fix broken deleting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* 1.5.2 (2018-11-)
+	* Bug fix: as of 1.5.0, when a Salesforce record is deleted, the corresponding WordPress record is not deleted. This release restores this functionality. Thanks to WordPress user @bswift for the report.
+
 * 1.5.1 (2018-11-03)
 	* New: update to version 2.1.1 of the ActionScheduler library.
 	* Bug fix: when processing more than 2000 records, the offset and limit combination fails due to Salesforce API restrictions. In this release, the plugin changes the date parameter on the API query to the value for the last processed record.

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -713,13 +713,20 @@ class Object_Sync_Sf_Salesforce_Pull {
 		if ( is_string( $object ) ) {
 			$object_id = $object;
 			// Load the Salesforce object data to save in WordPress. We need to make sure that this data does not get cached, which is consistent with other pull behavior as well as in other methods in this class.
-			$object = $sfapi->object_read(
-				$object_type,
-				$object_id,
-				array(
-					'cache' => false,
-				)
-			)['data'];
+			// We should only do this if we're not trying to delete data in WordPress - otherwise, we'll get a 404 from Salesforce and the delete will fail.
+			if ( $sf_sync_trigger != $this->mappings->sync_sf_delete ) { // trigger is a bit operator
+				$object = $sfapi->object_read(
+					$object_type,
+					$object_id,
+					array(
+						'cache' => false,
+					)
+				)['data'];
+			} else {
+				$object = array(
+					'Id' => $object,
+				);
+			} // gently handle deleted records
 		}
 
 		if ( is_int( $mapping ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,9 @@ This plugin can be relatively complicated, and sometimes other plugins can effec
 
 == Changelog ==
 
+* 1.5.2 (2018-11-)
+	* Bug fix: as of 1.5.0, when a Salesforce record is deleted, the corresponding WordPress record is not deleted. This release restores this functionality. Thanks to WordPress user @bswift for the report.
+
 * 1.5.1 (2018-11-03)
 	* New: update to version 2.1.1 of the ActionScheduler library.
 	* Bug fix: when processing more than 2000 records, the offset and limit combination fails due to Salesforce API restrictions. In this release, the plugin changes the date parameter on the API query to the value for the last processed record.


### PR DESCRIPTION
## What does this PR do?

This restores broken functionality so that when a Salesforce record is deleted, the corresponding WordPress record is deleted.

## How do I test this PR?

- Delete a Salesforce record that has a corresponding WordPress record via an object map.
