### PR TITLE
allow developers to set return format value

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* 1.5.2 (2018-11-)
+	* Developers: this release allows API calls that return data from Salesforce to return either json, the full PHP array (the default) or both, if the `$options` array is populated. Thanks to WordPress user @yanlep for the request.
+
 * 1.5.1 (2018-11-03)
 	* New: update to version 2.1.1 of the ActionScheduler library.
 	* Bug fix: when processing more than 2000 records, the offset and limit combination fails due to Salesforce API restrictions. In this release, the plugin changes the date parameter on the API query to the value for the last processed record.

--- a/classes/salesforce.php
+++ b/classes/salesforce.php
@@ -370,10 +370,27 @@ class Object_Sync_Sf_Salesforce {
 				'body'    => '',
 			);
 			curl_close( $curl );
-			return array(
+
+			$result = array(
 				'code' => $code,
-				'data' => $data,
 			);
+
+			$return_format = isset( $options['return_format'] ) ? $options['return_format'] : 'array';
+
+			switch ( $return_format ) {
+				case 'array':
+					$result['data'] = $data;
+					break;
+				case 'json':
+					$result['json'] = wp_json_encode( $data );
+					break;
+				case 'both':
+					$result['json'] = wp_json_encode( $data );
+					$result['data'] = $data;
+					break;
+			}
+
+			return $result;
 		}
 
 		if ( ( ord( $json_response[0] ) == 0x1f ) && ( ord( $json_response[1] ) == 0x8b ) ) {
@@ -460,10 +477,27 @@ class Object_Sync_Sf_Salesforce {
 
 		curl_close( $curl );
 
-		return array(
+		$result = array(
 			'code' => $code,
-			'data' => $data,
 		);
+
+		$return_format = isset( $options['return_format'] ) ? $options['return_format'] : 'array';
+
+		switch ( $return_format ) {
+			case 'array':
+				$result['data'] = $data;
+				break;
+			case 'json':
+				$result['json'] = $json_response;
+				break;
+			case 'both':
+				$result['json'] = $json_response;
+				$result['data'] = $data;
+				break;
+		}
+
+		return $result;
+
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -198,6 +198,9 @@ This plugin can be relatively complicated, and sometimes other plugins can effec
 
 == Changelog ==
 
+* 1.5.2 (2018-11-)
+    * Developers: this release allows API calls that return data from Salesforce to return either json, the full PHP array (the default) or both, if the `$options` array is populated. Thanks to WordPress user @yanlep for the request.
+
 * 1.5.1 (2018-11-03)
 	* New: update to version 2.1.1 of the ActionScheduler library.
 	* Bug fix: when processing more than 2000 records, the offset and limit combination fails due to Salesforce API restrictions. In this release, the plugin changes the date parameter on the API query to the value for the last processed record.


### PR DESCRIPTION
## What does this PR do?

When Salesforce returns data from an API call, this PR allows developers to set whether they want json, the PHP array, or both to be returned.