### PR TITLE
Fix pull records that are skipped when they shouldn't be

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1828,8 +1828,11 @@ class Object_Sync_Sf_Admin {
 	* @return array $args
 	*/
 	private function version_options() {
+		$args = array();
+		if ( defined( 'OBJECT_SYNC_SF_SALESFORCE_API_VERSION' ) || ! isset( $_GET['page'] ) || 'object-sync-salesforce-admin' !== $_GET['page'] ) {
+			return $args;
+		}
 		$versions = $this->salesforce['sfapi']->get_api_versions();
-		$args     = array();
 		foreach ( $versions['data'] as $key => $value ) {
 			$args[] = array(
 				'value' => $value['version'],

--- a/classes/logging.php
+++ b/classes/logging.php
@@ -211,7 +211,7 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 	 * @access      public
 	 * @since       1.0
 	 *
-	 * @param       string $title A log post title.
+	 * @param       string|array $title_or_params A log post title, or the full array of parameters
 	 * @param       string $message The log message.
 	 * @param       string|0 $trigger The type of log triggered. Usually one of: debug, notice, warning, error.
 	 * @param       int $parent The parent WordPress object.
@@ -222,7 +222,18 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 	 *
 	 * @return      void
 	 */
-	public function setup( $title, $message, $trigger = 0, $parent = 0, $status ) {
+	public function setup( $title_or_params, $message = '', $trigger = 0, $parent = 0, $status = '' ) {
+
+		if ( is_array( $title_or_params ) ) {
+			$title   = $title_or_params['title'];
+			$message = $title_or_params['message'];
+			$trigger = $title_or_params['trigger'];
+			$parent  = $title_or_params['parent'];
+			$status  = $title_or_params['status'];
+		} else {
+			$title = $title_or_params;
+		}
+
 		if ( '1' === $this->enabled && in_array( $status, maybe_unserialize( $this->statuses_to_log ), true ) ) {
 			$triggers_to_log = get_option( $this->option_prefix . 'triggers_to_log', array() );
 			// if we force strict on this in_array, it fails because the mapping triggers are bit operators, as indicated in Object_Sync_Sf_Mapping class's method __construct()

--- a/classes/salesforce.php
+++ b/classes/salesforce.php
@@ -1106,14 +1106,16 @@ class Object_Sync_Sf_Salesforce {
 	*   Salesforce external id field name.
 	* @param string $value
 	*   Value of external id.
+	* @param array $options
+	*   Optional options to pass to the API call
 	*
 	* @return object
 	*   Object of the requested Salesforce object.
 	*
 	* part of core API calls
 	*/
-	public function object_readby_external_id( $name, $field, $value ) {
-		return $this->api_call( "sobjects/{$name}/{$field}/{$value}" );
+	public function object_readby_external_id( $name, $field, $value, $options = array() ) {
+		return $this->api_call( "sobjects/{$name}/{$field}/{$value}", array(), 'GET', $options );
 	}
 
 	/**

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -322,7 +322,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 						if ( false === $pull_allowed ) {
 							// update the current state so we don't end up on the same record again if the loop fails
 							update_option( $this->option_prefix . 'last_pull_id', $result['Id'] );
-
 							if ( 1 === (int) $this->debug ) {
 								// create log entry for failed pull
 								$status = 'debug';
@@ -347,7 +346,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 								$logging->setup( $result );
 							}
-
 							continue;
 						}
 
@@ -365,7 +363,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 						// update the current state so we don't end up on the same record again if the loop fails
 						update_option( $this->option_prefix . 'last_pull_id', $result['Id'] );
-
 						if ( 1 === (int) $this->debug ) {
 							// create log entry for failed pull
 							$status = 'debug';
@@ -387,9 +384,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 								'parent'  => '',
 								'status'  => $status,
 							);
-
 							$logging->setup( $result );
-						}
+						} // end of debug
 					} // end if
 				} // end foreach
 				if ( true === $this->batch_soql_queries ) {
@@ -1591,6 +1587,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		// get the last pull modified date
 		$last_pull_modified_date = get_option( $this->option_prefix . 'last_pull_modified_date_' . $type );
 		// update the last sync timestamp for this content type
+		update_option( $this->option_prefix . 'pull_last_sync_' . $type, current_time( 'timestamp', true ) );
 		// having updated the last sync timestamp, regenerate the SOQL query object
 		$soql = $this->get_pull_query( $type, $salesforce_mapping );
 		return $soql;

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -1609,8 +1609,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 	*
 	*/
 	private function increment_current_type_query( $type, $salesforce_mapping ) {
-		// get the last pull modified date
-		$last_pull_modified_date = get_option( $this->option_prefix . 'last_pull_modified_date_' . $type );
 		// update the last sync timestamp for this content type
 		update_option( $this->option_prefix . 'pull_last_sync_' . $type, current_time( 'timestamp', true ) );
 		// having updated the last sync timestamp, regenerate the SOQL query object

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -391,6 +391,16 @@ class Object_Sync_Sf_Salesforce_Pull {
 				if ( true === $this->batch_soql_queries ) {
 					// if applicable, process the next batch of records
 					$this->get_next_record_batch( $last_sync, $salesforce_mapping, $map_sync_triggers, $type, $version_path, $query_options, $response );
+				} else {
+					// update or clear the stored query since the loop has successfully finished.
+					end( $response['records'] );
+					$last_record_key = key( $response['records'] );
+					// if we've just done the last item in the recordset, go ahead and clear the query. we don't need to offset.
+					if ( $last_record_key === $key ) {
+						$this->clear_current_type_query( $type );
+					} else {
+						update_option( $this->option_prefix . 'currently_pulling_query_' . $type, $serialized_query );
+					}
 				} // end if
 			} elseif ( 0 === count( $response['records'] ) && false === $this->batch_soql_queries ) {
 				// only update/clear these option values if we are currently still processing a query

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -344,7 +344,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$result = array(
 					'title'   => $title,
 					'message' => $response['message'],
-					'trigger' => $sf_mapping['sync_triggers'],
+					'trigger' => $salesforce_mapping['sync_triggers'],
 					'parent'  => '',
 					'status'  => $status,
 				);

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -248,10 +248,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 			if ( ! isset( $response['errorCode'] ) && 0 < count( $response['records'] ) ) {
 				// Write items to the queue.
 				foreach ( $response['records'] as $key => $result ) {
-
 					// if we've already pulled, or tried to pull, the current ID, don't do it again.
 					if ( get_option( $this->option_prefix . 'last_pull_id', '' ) === $result['Id'] ) {
-
 						if ( 1 === (int) $this->debug ) {
 							// create log entry for failed pull
 							$status = 'debug';
@@ -340,7 +338,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 							),
 							$this->schedule_name
 						);
-
 						// update the current state so we don't end up on the same record again if the loop fails
 						update_option( $this->option_prefix . 'last_pull_id', $result['Id'] );
 						if ( 1 === (int) $this->debug ) {

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -341,13 +341,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 				}
 
-				$logging->setup(
-					$title,
-					$response['message'],
-					$sf_mapping['sync_triggers'],
-					'',
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => $response['message'],
+					'trigger' => $sf_mapping['sync_triggers'],
+					'parent'  => '',
+					'status'  => $status,
 				);
+
+				$logging->setup( $result );
+
+				return $result;
 
 			} // End if().
 		} // End foreach().
@@ -726,6 +730,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		$transients_to_delete = array();
 
+		$results = array();
+
 		foreach ( $salesforce_mappings as $salesforce_mapping ) {
 
 			// this returns the row that maps the individual Salesforce row to the individual WordPress row
@@ -742,14 +748,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 				$title = sprintf( esc_html__( 'Error: Salesforce Pull: unable to process queue item because it has no Salesforce Id.', 'object-sync-for-salesforce' ) );
 
-				$logging->setup(
-					$title,
-					print_r( $object, true ), // log whatever we have in the event of this error, so print the array
-					$sf_sync_trigger,
-					0, // parent id goes here but we don't have one, so make it 0
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => print_r( $object, true ), // log whatever we have in the event of this error, so print the array
+					'trigger' => $sf_sync_trigger,
+					'parent'  => 0, // parent id goes here but we don't have one, so make it 0
+					'status'  => $status,
 				);
-				return;
+
+				$logging->setup( $result );
+
+				$results[] = $result;
 				continue;
 			}
 
@@ -820,13 +829,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 								esc_attr( $mapping_object['salesforce_id'] )
 							);
 
-							$logging->setup(
-								$title,
-								$e->getMessage(),
-								$sf_sync_trigger,
-								$mapping_object['wordpress_id'],
-								$status
+							$result = array(
+								'title'   => $title,
+								'message' => $e->getMessage(),
+								'trigger' => $sf_sync_trigger,
+								'parent'  => $mapping_object['wordpress_id'],
+								'status'  => $status,
 							);
+
+							$logging->setup( $result );
+
+							$results[] = $result;
 
 							if ( false === $hold_exceptions ) {
 								throw $e;
@@ -862,13 +875,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 								esc_attr( $mapping_object['salesforce_id'] )
 							);
 
-							$logging->setup(
-								$title,
-								'',
-								$sf_sync_trigger,
-								$mapping_object['wordpress_id'],
-								$status
+							$result = array(
+								'title'   => $title,
+								'message' => '',
+								'trigger' => $sf_sync_trigger,
+								'parent'  => $mapping_object['wordpress_id'],
+								'status'  => $status,
 							);
+
+							$logging->setup( $result );
+
+							$results[] = $result;
 
 							// hook for pull success
 							do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
@@ -905,13 +922,18 @@ class Object_Sync_Sf_Salesforce_Pull {
 							esc_attr( $mapping_object['salesforce_id'] )
 						);
 
-						$logging->setup(
-							$title,
-							$more_ids,
-							$sf_sync_trigger,
-							$mapping_object['wordpress_id'],
-							$status
+						$result = array(
+							'title'   => $title,
+							'message' => $more_ids,
+							'trigger' => $sf_sync_trigger,
+							'parent'  => $mapping_object['wordpress_id'],
+							'status'  => $status,
 						);
+
+						$logging->setup( $result );
+
+						$results[] = $result;
+
 					} // End if().
 
 					// delete the map row from WordPress after the WordPress row has been deleted
@@ -1057,13 +1079,18 @@ class Object_Sync_Sf_Salesforce_Pull {
 									$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 								}
 								$parent = 0;
-								$logging->setup(
-									$title,
-									$body,
-									$sf_sync_trigger,
-									$parent,
-									$status
+
+								$result = array(
+									'title'   => $title,
+									'message' => $body,
+									'trigger' => $sf_sync_trigger,
+									'parent'  => $parent,
+									'status'  => $status,
 								);
+
+								$logging->setup( $result );
+
+								$results[] = $result;
 							} // End if().
 						} // End if().
 
@@ -1103,13 +1130,19 @@ class Object_Sync_Sf_Salesforce_Pull {
 							} else {
 								$parent = 0;
 							}
-							$logging->setup(
-								$title,
-								$body,
-								$sf_sync_trigger,
-								$parent,
-								$status
+
+							$result = array(
+								'title'   => $title,
+								'message' => $body,
+								'trigger' => $sf_sync_trigger,
+								'parent'  => $parent,
+								'status'  => $status,
 							);
+
+							$logging->setup( $result );
+
+							$results[] = $result;
+
 							// exit out of here without saving any data in WordPress
 							continue;
 						} // End if().
@@ -1177,13 +1210,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 						$parent = 0;
 					}
 
-					$logging->setup(
-						$title,
-						$e->getMessage(),
-						$sf_sync_trigger,
-						$parent,
-						$status
+					$result = array(
+						'title'   => $title,
+						'message' => $e->getMessage(),
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $parent,
+						'status'  => $status,
 					);
+
+					$logging->setup( $result );
+
+					$results[] = $result;
 
 					if ( false === $hold_exceptions ) {
 						throw $e;
@@ -1232,13 +1269,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 						esc_attr( $object['Id'] )
 					);
 
-					$logging->setup(
-						$title,
-						'',
-						$sf_sync_trigger,
-						$wordpress_id,
-						$status
+					$result = array(
+						'title'   => $title,
+						'message' => '',
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $wordpress_id,
+						'status'  => $status,
 					);
+
+					$logging->setup( $result );
+
+					$results[] = $result;
 
 					// update that mapping object
 					$mapping_object['wordpress_id'] = $wordpress_id;
@@ -1278,13 +1319,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 						print_r( $result['errors'], true ) // if we get this error, we need to know whatever we have
 					);
 
-					$logging->setup(
-						$title,
-						$body,
-						$sf_sync_trigger,
-						$wordpress_id,
-						$status
+					$result = array(
+						'title'   => $title,
+						'message' => $body,
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $wordpress_id,
+						'status'  => $status,
 					);
+
+					$logging->setup( $result );
+
+					$results[] = $result;
 
 					// hook for pull fail
 					do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
@@ -1335,13 +1380,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 						esc_attr( $object['Id'] )
 					);
 
-					$logging->setup(
-						$title,
-						'',
-						$sf_sync_trigger,
-						$mapping_object['wordpress_id'],
-						$status
+					$result = array(
+						'title'   => $title,
+						'message' => '',
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $mapping_object['wordpress_id'],
+						'status'  => $status,
 					);
+
+					$logging->setup( $result );
+
+					$results[] = $result;
 
 					// hook for pull success
 					do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
@@ -1365,13 +1414,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 						esc_attr( $object['Id'] )
 					);
 
-					$logging->setup(
-						$title,
-						$e->getMessage(),
-						$sf_sync_trigger,
-						$mapping_object['wordpress_id'],
-						$status
+					$result = array(
+						'title'   => $title,
+						'message' => $e->getMessage(),
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $mapping_object['wordpress_id'],
+						'status'  => $status,
 					);
+
+					$logging->setup( $result );
+
+					$results[] = $result;
 
 					$mapping_object['last_sync_status']  = $this->mappings->status_error;
 					$mapping_object['last_sync_message'] = $e->getMessage();
@@ -1418,6 +1471,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 		if ( ! empty( $exception ) ) {
 			throw $exception;
 		}
+
+		return $results;
 
 	}
 

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -263,6 +263,32 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					// if we've already pulled, or tried to pull, the current ID, don't do it again.
 					if ( get_option( $this->option_prefix . 'last_pull_id', '' ) === $result['Id'] ) {
+
+						if ( 1 === (int) $this->debug ) {
+							// create log entry for failed pull
+							$status = 'debug';
+							// translators: placeholders are: 1) the Salesforce ID
+							$title = sprintf( esc_html__( 'Debug: Salesforce ID %1$s has already been attempted.', 'object-sync-for-salesforce' ),
+								absint( $result['Id'] )
+							);
+
+							if ( isset( $this->logging ) ) {
+								$logging = $this->logging;
+							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+							}
+
+							$result = array(
+								'title'   => $title,
+								'message' => esc_html__( 'This ID has already been attempted so it was not pulled again.', 'object-sync-for-salesforce' ),
+								'trigger' => $salesforce_mapping['sync_triggers'],
+								'parent'  => '',
+								'status'  => $status,
+							);
+
+							$logging->setup( $result );
+						}
+
 						continue;
 					}
 
@@ -296,6 +322,32 @@ class Object_Sync_Sf_Salesforce_Pull {
 						if ( false === $pull_allowed ) {
 							// update the current state so we don't end up on the same record again if the loop fails
 							update_option( $this->option_prefix . 'last_pull_id', $result['Id'] );
+
+							if ( 1 === (int) $this->debug ) {
+								// create log entry for failed pull
+								$status = 'debug';
+								// translators: placeholders are: 1) the Salesforce ID
+								$title = sprintf( esc_html__( 'Debug: Salesforce ID %1$s is not allowed.', 'object-sync-for-salesforce' ),
+									absint( $result['Id'] )
+								);
+
+								if ( isset( $this->logging ) ) {
+									$logging = $this->logging;
+								} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+									$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+								}
+
+								$result = array(
+									'title'   => $title,
+									'message' => esc_html__( 'This ID is not pullable so it was skipped.', 'object-sync-for-salesforce' ),
+									'trigger' => $salesforce_mapping['sync_triggers'],
+									'parent'  => '',
+									'status'  => $status,
+								);
+
+								$logging->setup( $result );
+							}
+
 							continue;
 						}
 
@@ -314,6 +366,30 @@ class Object_Sync_Sf_Salesforce_Pull {
 						// update the current state so we don't end up on the same record again if the loop fails
 						update_option( $this->option_prefix . 'last_pull_id', $result['Id'] );
 
+						if ( 1 === (int) $this->debug ) {
+							// create log entry for failed pull
+							$status = 'debug';
+							// translators: placeholders are: 1) the Salesforce ID
+							$title = sprintf( esc_html__( 'Debug: Salesforce ID %1$s has been successfully pulled.', 'object-sync-for-salesforce' ),
+								absint( $result['Id'] )
+							);
+
+							if ( isset( $this->logging ) ) {
+								$logging = $this->logging;
+							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+							}
+
+							$result = array(
+								'title'   => $title,
+								'message' => esc_html__( 'This ID has been successfully pulled. It cannot be pulled again.', 'object-sync-for-salesforce' ),
+								'trigger' => $salesforce_mapping['sync_triggers'],
+								'parent'  => '',
+								'status'  => $status,
+							);
+
+							$logging->setup( $result );
+						}
 					} // end if
 				} // end foreach
 				if ( true === $this->batch_soql_queries ) {
@@ -795,6 +871,31 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$salesforce_pushing = (int) get_transient( 'salesforce_pushing_' . $mapping_object_id_transient );
 			if ( 1 === $salesforce_pushing ) {
 				$transients_to_delete[] = $mapping_object_id_transient;
+				if ( 1 === (int) $this->debug ) {
+					// create log entry for failed pull
+					$status = 'debug';
+					// translators: placeholders are: 1) the mapping object ID transient
+					$title = sprintf( esc_html__( 'Debug: mapping object transient ID %1$s is currently pushing, so we do not pull it.', 'object-sync-for-salesforce' ),
+						$mapping_object_id_transient
+					);
+
+					if ( isset( $this->logging ) ) {
+						$logging = $this->logging;
+					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+					}
+
+					$result = array(
+						'title'   => $title,
+						'message' => '',
+						'trigger' => $salesforce_mapping['sync_triggers'],
+						'parent'  => '',
+						'status'  => $status,
+					);
+
+					$logging->setup( $result );
+				}
+
 				continue;
 			}
 

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -381,9 +381,12 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$last_record_key = key( $response['records'] );
 					if ( true === $does_next_offset_have_results ) {
 						// serialize the currently running SOQL query and store it for this type
-						$soql             = $this->get_offset_query( $type, $soql );
-						$serialized_query = maybe_serialize( $soql );
-						update_option( $this->option_prefix . 'next_query_' . $type, $serialized_query );
+						$serialized_current_query = maybe_serialize( $soql );
+						update_option( $this->option_prefix . 'currently_pulling_query_' . $type, $serialized_current_query );
+
+						$soql                  = $this->get_offset_query( $type, $soql );
+						$serialized_next_query = maybe_serialize( $soql );
+						update_option( $this->option_prefix . 'next_query_' . $type, $serialized_next_query );
 					} elseif ( $last_record_key === $key ) {
 						// clear the stored query. we don't need to offset and we've finished the loop.
 						$this->clear_current_type_query( $type );

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -373,7 +373,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					// If it does, we regenerate the query so it will have an offset next time it runs.
 					// If it does not, we clear the query if we've just processed the last row.
 					// this allows us to run an offset on the stored query instead of clearing it.
-					$does_next_offset_have_results = $this->get_offset_query( $type, $soql, true );
+					$does_next_offset_have_results = $this->get_offset_query( $type, $salesforce_mapping, $soql, true );
 					end( $response['records'] );
 					$last_record_key = key( $response['records'] );
 					if ( true === $does_next_offset_have_results ) {
@@ -381,7 +381,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						$serialized_current_query = maybe_serialize( $soql );
 						update_option( $this->option_prefix . 'currently_pulling_query_' . $type, $serialized_current_query );
 
-						$soql                  = $this->get_offset_query( $type, $soql );
+						$soql                  = $this->get_offset_query( $type, $salesforce_mapping, $soql );
 						$serialized_next_query = maybe_serialize( $soql );
 						update_option( $this->option_prefix . 'next_query_' . $type, $serialized_next_query );
 					} elseif ( $last_record_key === $key ) {
@@ -497,12 +497,13 @@ class Object_Sync_Sf_Salesforce_Pull {
 	* When batchSize is not in use, run a check with an offset.
 	*
 	* @param string $type the Salesforce object type
+	* @param array $salesforce_mapping the map between object types
 	* @param object $soql the SOQL object
 	* @param bool $check are we just checking?
 	* @return object|bool $soql|$does_next_offset_have_results
 	*
 	*/
-	private function get_offset_query( $type, $soql, $check = false ) {
+	private function get_offset_query( $type, $salesforce_mapping, $soql, $check = false ) {
 		$sfapi         = $this->salesforce['sfapi'];
 		$query_options = array(
 			'cache' => false,

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -516,19 +516,15 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		// set an offset. if there is a saved offset, add the limit to it and move on. otherwise, use the limit.
 		$soql->offset = isset( $saved_query->offset ) ? $saved_query->offset + $soql->limit : $soql->limit;
-		error_log( 'offset is ' . $soql->offset );
 		if ( $soql->offset > $this->max_soql_size ) {
-			error_log( 'offset is too high. regenerate' );
 			// regenerate the SOQL query so we can increment the last pull modified date value from Salesforce. This allows us to go beyond 2000 records as long as the records were modified at different times.
 			$soql = $this->increment_current_type_query( $type, $salesforce_mapping );
 		}
 
 		if ( false === $check ) {
-			error_log( 'just return the query' );
 			return $soql;
 		} else {
 			$does_next_offset_have_results = false;
-			error_log( 'offset soql query is ' . (string) $soql );
 			// Execute query
 			// have to cast it to string to make sure it uses the magic method
 			// we don't want to cache this because timestamps

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -1135,6 +1135,18 @@ class Object_Sync_Sf_Salesforce_Push {
 
 			} // End try().
 
+			if ( ! isset( $salesforce_data ) ) {
+				// if we didn't set $salesforce_data already, set it now
+				$sf_object       = $sfapi->object_read(
+					$mapping['salesforce_object'],
+					$mapping_object['salesforce_id'],
+					array(
+						'cache' => false,
+					)
+				);
+				$salesforce_data = $sf_object['data'];
+			}
+
 			// tell the mapping object - whether it is new or already existed - how we just used it
 			$mapping_object['last_sync_action'] = 'push';
 			$mapping_object['last_sync']        = current_time( 'mysql' );

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -393,14 +393,16 @@ class Object_Sync_Sf_Salesforce_Push {
 				esc_attr( $object_id_field )
 			);
 
-			$logging->setup(
-				$title,
-				print_r( $object, true ), // print this array because if this happens, something weird has happened and we want to log whatever we have
-				$sf_sync_trigger,
-				0, // parent id goes here but we don't have one, so make it 0
-				$status
+			$result = array(
+				'title'   => $title,
+				'message' => print_r( $object, true ), // print this array because if this happens, something weird has happened and we want to log whatever we have
+				'trigger' => $sf_sync_trigger,
+				'parent'  => 0, // parent id goes here but we don't have one, so make it 0,
+				'status'  => $status,
 			);
-			return;
+
+			$logging->setup( $result );
+			return $result;
 		} // End if().
 
 		// load mappings that match this criteria
@@ -412,66 +414,136 @@ class Object_Sync_Sf_Salesforce_Push {
 			)
 		);
 
+		$results = array();
+
 		foreach ( $sf_mappings as $mapping ) { // for each mapping of this object
 			$map_sync_triggers = $mapping['sync_triggers'];
 
-			// these are bit operators, so we leave out the strict
-			if ( isset( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers ) ) { // wp or sf crud event
+			$push_allowed = $this->is_push_allowed( $object_type, $object, $sf_sync_trigger, $mapping, $map_sync_triggers );
 
-				// hook to allow other plugins to prevent a push per-mapping.
-				$push_allowed = apply_filters( $this->option_prefix . 'push_object_allowed', true, $object_type, $object, $sf_sync_trigger, $mapping );
+			if ( false === $push_allowed ) {
 
-				// example to keep from pushing the user with id of 1
-				/*
-				add_filter( 'object_sync_for_salesforce_push_object_allowed', 'check_user', 10, 5 );
-				// can always reduce this number if all the arguments are not necessary
-				function check_user( $push_allowed, $object_type, $object, $sf_sync_trigger, $mapping ) {
-					if ( $object_type === 'user' && $object['Id'] === 1 ) {
-						return FALSE;
-					}
-				}
-				*/
+				// we need to get the WordPress id here so we can check to see if the object already has a map
+				$structure = $this->wordpress->get_wordpress_table_structure( $object_type );
+				$object_id = $structure['id_field'];
 
-				if ( false === $push_allowed ) {
-					continue;
-				}
+				// this returns the row that maps the individual WordPress row to the individual Salesfoce row
+				$mapping_object = $this->mappings->load_by_wordpress( $object_type, $object[ "$object_id" ] );
 
-				// push drafts if the setting says so
-				// post status is draft, or post status is inherit and post type is not attachment
-				if ( ( ! isset( $mapping['push_drafts'] ) || '1' !== $mapping['push_drafts'] ) && isset( $object['post_status'] ) && ( 'draft' === $object['post_status'] || ( 'inherit' === $object['post_status'] && 'attachment' !== $object['post_type'] ) ) ) {
-					// skip this object if it is a draft and the fieldmap settings told us to ignore it
-					continue;
-				}
+				// hook to allow other plugins to define or alter the mapping object
+				$mapping_object = apply_filters( $this->option_prefix . 'push_mapping_object', $mapping_object, $object, $mapping );
 
-				if ( isset( $mapping['push_async'] ) && ( '1' === $mapping['push_async'] ) && false === $manual ) {
-					// this item is async and we want to save it to the queue
-
-					// if we determine that the below code does not perform well, worst case scenario is we could save $data to a custom table, and pass the id to the callback method.
-					/*$data = array(
-						'object_type'     => $object_type,
-						'object'          => $object,
-						'mapping'         => $mapping['id'],
-						'sf_sync_trigger' => $sf_sync_trigger,
-					);*/
-
-					// add a queue action to push data to salesforce
-					// this means we don't need the frequency for this method anymore, i think
-					$this->queue->add(
-						$this->schedulable_classes[ $this->schedule_name ]['callback'],
-						array(
-							'object_type'     => $object_type,
-							'object'          => filter_var( $object[ $object_id_field ], FILTER_VALIDATE_INT ),
-							'mapping'         => filter_var( $mapping['id'], FILTER_VALIDATE_INT ),
-							'sf_sync_trigger' => $sf_sync_trigger,
-						),
-						$this->schedule_name
-					);
+				// are these objects already connected in WordPress?
+				if ( isset( $mapping_object['id'] ) ) {
+					$is_new = false;
 				} else {
-					// this one is not async. do it immediately.
-					$push = $this->salesforce_push_sync_rest( $object_type, $object, $mapping, $sf_sync_trigger );
-				} // End if().
-			} // End if(). if the trigger does not match our requirements, skip it
+					$is_new = true;
+				}
+
+				$status = 'error';
+				// create log entry for not allowed push
+				if ( isset( $this->logging ) ) {
+					$logging = $this->logging;
+				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+				}
+
+				$op = '';
+				switch ( $sf_sync_trigger ) {
+					case $this->mappings->sync_wordpress_create:
+						if ( true === $is_new ) {
+							$op = 'Create';
+						}
+						break;
+					case $this->mappings->sync_wordpress_update:
+						if ( false === $is_new ) {
+							$op = 'Update';
+						}
+						break;
+					case $this->mappings->sync_wordpress_delete:
+						if ( false === $is_new ) {
+							$op = 'Delete';
+						}
+						break;
+				}
+
+				// translators: placeholders are: 1) the name of the current operation, 2) the name of the WordPress object type, 3) the name of the WordPress ID field, 4) the value of the object's ID in WordPress, 5) the name of the Salesforce object
+				$title = sprintf( esc_html__( 'Error: %1$s Salesforce %5$s with WordPress %2$s with %3$s of %4$s was not allowed by this fieldmap.', 'object-sync-for-salesforce' ),
+					esc_attr( $op ),
+					esc_attr( $mapping['wordpress_object'] ),
+					esc_attr( $object_id_field ),
+					esc_attr( $object[ $object_id_field ] ),
+					esc_attr( $mapping['salesforce_object'] )
+				);
+
+				$result = array(
+					'title'   => $title,
+					'message' => '',
+					'trigger' => $sf_sync_trigger,
+					'parent'  => esc_attr( $object[ $object_id_field ] ),
+					'status'  => 'error',
+				);
+				if ( '' !== $op ) {
+					$logging->setup( $result );
+				}
+				$results[] = $result;
+				continue;
+			}
+
+			// push drafts if the setting says so
+			// post status is draft, or post status is inherit and post type is not attachment
+			if ( ( ! isset( $mapping['push_drafts'] ) || '1' !== $mapping['push_drafts'] ) && isset( $object['post_status'] ) && ( 'draft' === $object['post_status'] || ( 'inherit' === $object['post_status'] && 'attachment' !== $object['post_type'] ) ) ) {
+				// skip this object if it is a draft and the fieldmap settings told us to ignore it
+				continue;
+			}
+
+			if ( isset( $mapping['push_async'] ) && ( '1' === $mapping['push_async'] ) && false === $manual ) {
+				// this item is async and we want to save it to the queue
+
+				// if we determine that the below code does not perform well, worst case scenario is we could save $data to a custom table, and pass the id to the callback method.
+				/*$data = array(
+					'object_type'     => $object_type,
+					'object'          => $object,
+					'mapping'         => $mapping['id'],
+					'sf_sync_trigger' => $sf_sync_trigger,
+				);*/
+
+				// add a queue action to push data to salesforce
+				// this means we don't need the frequency for this method anymore, i think
+				$this->queue->add(
+					$this->schedulable_classes[ $this->schedule_name ]['callback'],
+					array(
+						'object_type'     => $object_type,
+						'object'          => filter_var( $object[ $object_id_field ], FILTER_VALIDATE_INT ),
+						'mapping'         => filter_var( $mapping['id'], FILTER_VALIDATE_INT ),
+						'sf_sync_trigger' => $sf_sync_trigger,
+					),
+					$this->schedule_name
+				);
+
+				// translators: placeholders are: 1) the name of the WordPress object type, 2) the name of the WordPress ID field, 3) the value of the object's ID in WordPress, 4) the name of the Salesforce object
+				$title = sprintf( esc_html__( 'Success: Add to queue: Push WordPress %1$s with %2$s of %3$s to Salesforce %4$s.', 'object-sync-for-salesforce' ),
+					esc_attr( $mapping['wordpress_object'] ),
+					esc_attr( $object_id_field ),
+					esc_attr( $object[ $object_id_field ] ),
+					esc_attr( $mapping['salesforce_object'] )
+				);
+
+				$result    = array(
+					'title'   => $title,
+					'message' => '',
+					'trigger' => $sf_sync_trigger,
+					'parent'  => esc_attr( $object[ $object_id_field ] ),
+					'status'  => 'success',
+				);
+				$results[] = $result;
+			} else {
+				// this one is not async. do it immediately.
+				$push      = $this->salesforce_push_sync_rest( $object_type, $object, $mapping, $sf_sync_trigger );
+				$results[] = $push;
+			} // End if().
 		} // End foreach().
+		return $results;
 	}
 
 	/**
@@ -559,13 +631,15 @@ class Object_Sync_Sf_Salesforce_Push {
 							esc_attr( $object[ "$object_id" ] )
 						);
 
-						$logging->setup(
-							$title,
-							$e->getMessage(),
-							$sf_sync_trigger,
-							$object[ "$object_id" ],
-							$status
+						$result = array(
+							'title'   => $title,
+							'message' => $e->getMessage(),
+							'trigger' => $sf_sync_trigger,
+							'parent'  => $object[ "$object_id" ],
+							'status'  => $status,
 						);
+
+						$logging->setup( $result );
 
 						// hook for push fail
 						do_action( $this->option_prefix . 'push_fail', $op, $sfapi->response, $synced_object, $object_id );
@@ -591,13 +665,15 @@ class Object_Sync_Sf_Salesforce_Push {
 							esc_attr( $object[ "$object_id" ] )
 						);
 
-						$logging->setup(
-							$title,
-							'',
-							$sf_sync_trigger,
-							$object[ "$object_id" ],
-							$status
+						$result = array(
+							'title'   => $title,
+							'message' => '',
+							'trigger' => $sf_sync_trigger,
+							'parent'  => $object[ "$object_id" ],
+							'status'  => $status,
 						);
+
+						$logging->setup( $result );
 
 						// hook for push success
 						do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $object_id );
@@ -634,13 +710,16 @@ class Object_Sync_Sf_Salesforce_Push {
 						esc_attr( $object[ "$object_id" ] )
 					);
 
-					$logging->setup(
-						$title,
-						$more_ids,
-						$sf_sync_trigger,
-						$object[ "$object_id" ],
-						$status
+					$result = array(
+						'title'   => $title,
+						'message' => $more_ids,
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $object[ "$object_id" ],
+						'status'  => $status,
 					);
+
+					$logging->setup( $result );
+
 				} // End if().
 
 				// delete the map row from WordPress after the Salesforce row has been deleted
@@ -649,7 +728,7 @@ class Object_Sync_Sf_Salesforce_Push {
 
 			} // End if(). there is no map row
 
-			return;
+			return $result;
 		} // End if().
 
 		// are these objects already connected in WordPress?
@@ -807,13 +886,15 @@ class Object_Sync_Sf_Salesforce_Push {
 					esc_attr( $object[ "$object_id" ] )
 				);
 
-				$logging->setup(
-					$title,
-					$e->getMessage(),
-					$sf_sync_trigger,
-					$object[ "$object_id" ],
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => $e->getMessage(),
+					'trigger' => $sf_sync_trigger,
+					'parent'  => $object[ "$object_id" ],
+					'status'  => $status,
 				);
+
+				$logging->setup( $result );
 
 				// hook for push fail
 				do_action( $this->option_prefix . 'push_fail', $op, $sfapi->response, $synced_object );
@@ -850,13 +931,15 @@ class Object_Sync_Sf_Salesforce_Push {
 					esc_attr( $object[ "$object_id" ] )
 				);
 
-				$logging->setup(
-					$title,
-					'',
-					$sf_sync_trigger,
-					$object[ "$object_id" ],
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => '',
+					'trigger' => $sf_sync_trigger,
+					'parent'  => $object[ "$object_id" ],
+					'status'  => $status,
 				);
+
+				$logging->setup( $result );
 
 				// update that mapping object
 				$mapping_object['salesforce_id']     = $salesforce_id;
@@ -892,18 +975,20 @@ class Object_Sync_Sf_Salesforce_Push {
 					esc_html( $salesforce_data['message'] )
 				);
 
-				$logging->setup(
-					$title,
-					$body,
-					$sf_sync_trigger,
-					$object[ "$object_id" ],
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => $body,
+					'trigger' => $sf_sync_trigger,
+					'parent'  => $object[ "$object_id" ],
+					'status'  => $status,
 				);
+
+				$logging->setup( $result );
 
 				// hook for push fail
 				do_action( $this->option_prefix . 'push_fail', $op, $sfapi->response, $synced_object );
 
-				return;
+				return $result;
 			} // End if().
 		} else {
 			// $is_new is false here; we are updating an already mapped object
@@ -939,14 +1024,16 @@ class Object_Sync_Sf_Salesforce_Push {
 					esc_html( $mapping_object['object_updated'] )
 				);
 
-				$logging->setup(
-					$title,
-					$body,
-					$sf_sync_trigger,
-					$object[ "$object_id" ],
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => $body,
+					'trigger' => $sf_sync_trigger,
+					'parent'  => 0, // parent id goes here but we don't have one, so make it 0,
+					'status'  => $status,
 				);
-				return;
+
+				$logging->setup( $result );
+				return $result;
 			}
 
 			// try to make a Salesforce update call
@@ -984,13 +1071,15 @@ class Object_Sync_Sf_Salesforce_Push {
 					esc_attr( $object[ "$object_id" ] )
 				);
 
-				$logging->setup(
-					$title,
-					'',
-					$sf_sync_trigger,
-					$object[ "$object_id" ],
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => '',
+					'trigger' => $sf_sync_trigger,
+					'parent'  => 0, // parent id goes here but we don't have one, so make it 0,
+					'status'  => $status,
 				);
+
+				$logging->setup( $result );
 
 				// hook for push success
 				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $object_id );
@@ -1014,13 +1103,15 @@ class Object_Sync_Sf_Salesforce_Push {
 					esc_attr( $object[ "$object_id" ] )
 				);
 
-				$logging->setup(
-					$title,
-					$e->getMessage(),
-					$sf_sync_trigger,
-					$object[ "$object_id" ],
-					$status
+				$result = array(
+					'title'   => $title,
+					'message' => $e->getMessage(),
+					'trigger' => $sf_sync_trigger,
+					'parent'  => $object[ "$object_id" ],
+					'status'  => $status,
 				);
+
+				$logging->setup( $result );
 
 				$mapping_object['last_sync_status']  = $this->mappings->status_error;
 				$mapping_object['last_sync_message'] = $e->getMessage();
@@ -1035,9 +1126,11 @@ class Object_Sync_Sf_Salesforce_Push {
 			$mapping_object['last_sync']        = current_time( 'mysql' );
 
 			// update that mapping object
-			$result = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+			$map_result = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
 
 		} // End if(). this is the end of the if is_new stuff
+
+		return $result;
 
 	}
 
@@ -1084,6 +1177,61 @@ class Object_Sync_Sf_Salesforce_Push {
 
 		return $mapping_object;
 
+	}
+
+	/**
+	* Find out if push is allowed for this record
+	*
+	* @param string $type
+	*   WordPress object type
+	* @param array $object
+	*   Array of the WordPress object's data
+	* @param string $sf_sync_trigger
+	*   The current operation's trigger
+	* @param array $mapping
+	*   the fieldmap that maps the two object types
+	* @param array $map_sync_triggers
+	*
+	* @return bool $push_allowed
+	*   Whether all this stuff allows the $result to be pushed to Salesforce
+	*
+	*/
+	private function is_push_allowed( $object_type, $object, $sf_sync_trigger, $mapping, $map_sync_triggers ) {
+
+		// default is push is allowed
+		$push_allowed = true;
+
+		// if the current fieldmap does not allow the wp create trigger, we need to check if there is an object map for the WordPress object ID. if not, set push_allowed to false.
+		if ( ! in_array( $this->mappings->sync_wordpress_create, $map_sync_triggers ) ) {
+			$structure       = $this->wordpress->get_wordpress_table_structure( $object_type );
+			$object_id_field = $structure['id_field'];
+			$object_map      = $this->mappings->load_by_wordpress( $object_type, $object[ $object_id_field ] );
+			if ( empty( $object_map ) ) {
+				$push_allowed = false;
+			}
+		}
+
+		// these are bit operators, so we leave out the strict
+		if ( ! in_array( $sf_sync_trigger, $map_sync_triggers ) ) {
+			$push_allowed = false;
+		}
+
+		// hook to allow other plugins to prevent a push per-mapping.
+		$push_allowed = apply_filters( $this->option_prefix . 'push_object_allowed', $push_allowed, $object_type, $object, $sf_sync_trigger, $mapping );
+
+		// example to keep from pushing the user with ID of 1
+		/*
+		add_filter( 'object_sync_for_salesforce_push_object_allowed', 'check_user', 10, 5 );
+		// can always reduce this number if all the arguments are not necessary
+		function check_user( $push_allowed, $object_type, $object, $sf_sync_trigger, $mapping ) {
+			if ( 'user' === $object_type && 1 === $object['ID'] ) { // do not add user 1 to salesforce
+				$push_allowed = false;
+			}
+			return $push_allowed;
+		}
+		*/
+
+		return $push_allowed;
 	}
 
 }

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -955,6 +955,11 @@ class Object_Sync_Sf_Salesforce_Push {
 
 				$logging->setup( $result );
 
+				// right here we should change the pushing transient to the LastModifiedDate for the Salesforce object.
+				if ( isset( $salesforce_data['LastModifiedDate'] ) ) {
+					set_transient( 'salesforce_pushing_' . $mapping_object['id'], strtotime( $salesforce_data['LastModifiedDate'] ) );
+				}
+
 				// update that mapping object
 				$mapping_object['salesforce_id']     = $salesforce_id;
 				$mapping_object['last_sync_message'] = esc_html__( 'Mapping object updated via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__;
@@ -1145,6 +1150,11 @@ class Object_Sync_Sf_Salesforce_Push {
 					)
 				);
 				$salesforce_data = $sf_object['data'];
+			}
+
+			// right here we should change the pushing transient to the LastModifiedDate for the Salesforce object.
+			if ( isset( $salesforce_data['LastModifiedDate'] ) ) {
+				set_transient( 'salesforce_pushing_' . $mapping_object['id'], strtotime( $salesforce_data['LastModifiedDate'] ) );
 			}
 
 			// tell the mapping object - whether it is new or already existed - how we just used it


### PR DESCRIPTION
## What does this PR do?

Fixes #220, in which pulling a batch of modified records in Salesforce could result in some of them being incorrectly skipped, if any of them were correctly not allowed to process.

## How do I test this PR?

1. Create a fieldmap that allows updated records to be pulled, but not created records.
2. Update a record that is already mapped in Salesforce so it should be updated in WordPress.
3. Create a new record in Salesforce that should not be created in WordPress.

All of these should behave as expected, if the fix works.