### PR TITLE
224 fix salesforce delete

### DIFF
--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -563,9 +563,16 @@ class Object_Sync_Sf_Salesforce_Push {
 	*/
 	public function salesforce_push_sync_rest( $object_type, $object, $mapping, $sf_sync_trigger ) {
 
+		// when using async, this task receives the object id as an integer. otherwise, it receives the object data
 		if ( is_int( $object ) ) {
 			$object_id = $object;
-			$object    = $this->wordpress->get_wordpress_object_data( $object_type, $object_id );
+			// if this is NOT a deletion, try to get all of the object's data
+			if ( $sf_sync_trigger != $this->mappings->sync_wordpress_delete ) {
+				$object = $this->wordpress->get_wordpress_object_data( $object_type, $object_id );
+			} else {
+				// otherwise, flag it as a delete and limit what we try to get
+				$object = $this->wordpress->get_wordpress_object_data( $object_type, $object_id, true );
+			}
 		}
 
 		if ( is_int( $mapping ) ) {

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -159,7 +159,8 @@ class Object_Sync_Sf_Salesforce_Push {
 	* @param string $user_id
 	*/
 	public function delete_user( $user_id ) {
-		$user = $this->wordpress->get_wordpress_object_data( 'user', $user_id );
+		// flag that this item has been deleted
+		$user = $this->wordpress->get_wordpress_object_data( 'user', $user_id, true );
 		$this->object_delete( $user, 'user' );
 	}
 
@@ -241,7 +242,8 @@ class Object_Sync_Sf_Salesforce_Push {
 	* @param string $post_id
 	*/
 	public function delete_attachment( $post_id ) {
-		$attachment = $this->wordpress->get_wordpress_object_data( 'attachment', $post_id );
+		// flag that this item has been deleted
+		$attachment = $this->wordpress->get_wordpress_object_data( 'attachment', $post_id, true );
 		$this->object_delete( $attachment, 'attachment' );
 	}
 
@@ -310,7 +312,8 @@ class Object_Sync_Sf_Salesforce_Push {
 	* @param string $comment_id
 	*/
 	public function delete_comment( $comment_id ) {
-		$comment = $this->wordpress->get_wordpress_object_data( 'comment', $comment_id );
+		// flag that this item has been deleted
+		$comment = $this->wordpress->get_wordpress_object_data( 'comment', $comment_id, true );
 		$this->object_delete( $comment, 'comment' );
 	}
 

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -206,7 +206,13 @@ class Object_Sync_Sf_Salesforce_Push {
 			}
 		}
 
-		$post = $this->wordpress->get_wordpress_object_data( $post->post_type, $post_id );
+		// if it is NOT a deletion, don't flag it as such
+		if ( 1 !== $delete ) {
+			$post = $this->wordpress->get_wordpress_object_data( $post->post_type, $post_id );
+		} else {
+			// otherwise, flag that this item has been deleted
+			$post = $this->wordpress->get_wordpress_object_data( $post->post_type, $post_id, true );
+		}
 		if ( 1 === $update ) {
 			$this->object_update( $post, $post_type );
 		} elseif ( 1 === $delete ) {

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -332,10 +332,10 @@ class Object_Sync_Sf_WordPress {
 	 *
 	 * @param string $object_type The type of object.
 	 * @param string $object_id The ID of the object.
+	 * @param bool $is_deleted Whether the WordPress object has been deleted
 	 * @return array $wordpress_object
 	 */
-	public function get_wordpress_object_data( $object_type, $object_id ) {
-
+	public function get_wordpress_object_data( $object_type, $object_id, $is_deleted = false ) {
 		$wordpress_object       = array();
 		$object_table_structure = $this->get_wordpress_table_structure( $object_type );
 
@@ -347,6 +347,12 @@ class Object_Sync_Sf_WordPress {
 		$object_name     = $object_table_structure['object_name'];
 		$where           = $object_table_structure['where'];
 		$ignore_keys     = $object_table_structure['ignore_keys'];
+
+		if ( true === $is_deleted ) {
+			$wordpress_object              = array();
+			$wordpress_object[ $id_field ] = $object_id;
+			return $wordpress_object;
+		}
 
 		if ( 'user' === $object_type ) {
 			$data = get_userdata( $object_id );


### PR DESCRIPTION
## What does this PR do?

This fixes #224, which was preventing Salesforce records from being deleted when their corresponding WordPress records were deleted.

## How do I test this PR?

1. Delete a record in Salesforce that has a corresponding object map to a WordPress record.
2. Record is deleted in Salesforce.