### PR TITLE
Make the call to `wp_new_user_notification()` compatible with WP 5.1

### DIFF
--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -905,7 +905,7 @@ class Object_Sync_Sf_WordPress {
 
 				// Send notification of new user.
 				// todo: Figure out what permissions ought to get notifications for this and make sure it works the right way.
-				wp_new_user_notification( $user_id, null, 'admin user' );
+				wp_new_user_notification( $user_id, null, 'both' );
 
 			}
 		} else {


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/44293 and/or https://github.com/WordPress/WordPress/commit/655d44ffe813eb9a64e30a6339316338246e9efc

## What does this PR do?

As of 5.1, WordPress rejects calls to `wp_new_user_notification()` whose third argument isn't either `'admin'`, `'user'`, `'both'`, or `''`. Previously, the value this plugin passes (`'admin user'`) was treated the same as `'both'`; but when it's running on WP 5.1, this plugin doesn't send any notifications at all. This PR changes the third argument to `'both'`.

## How do I test this PR?

- Pull a Salesforce record in such a way as to trigger the creation of a WordPress user
- Confirm that notifications are sent to both the site administrator's and the new user's email addresses