### PR TITLE
Merge support

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -602,7 +602,7 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'token_url_path'                 => array(
-				'title'    => 'Token URL Path',
+				'title'    => __( 'Token URL Path', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page'     => $page,
 				'section'  => $section,
@@ -615,7 +615,7 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'api_version'                    => array(
-				'title'    => 'Salesforce API Version',
+				'title'    => __( 'Salesforce API Version', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page'     => $page,
 				'section'  => $section,
@@ -628,7 +628,7 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'object_filters'                 => array(
-				'title'    => 'Limit Salesforce Objects',
+				'title'    => __( 'Limit Salesforce Objects', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['checkboxes'],
 				'page'     => $page,
 				'section'  => $section,
@@ -638,13 +638,13 @@ class Object_Sync_Sf_Admin {
 					'desc'     => __( 'Allows you to limit which Salesforce objects can be mapped', 'object-sync-for-salesforce' ),
 					'items'    => array(
 						'triggerable' => array(
-							'text'    => 'Only Triggerable objects',
+							'text'    => __( 'Only Triggerable objects', 'object-sync-for-salesforce' ),
 							'id'      => 'triggerable',
 							'desc'    => '',
 							'default' => $this->default_triggerable,
 						),
 						'updateable'  => array(
-							'text'    => 'Only Updateable objects',
+							'text'    => __( 'Only Updateable objects', 'object-sync-for-salesforce' ),
 							'id'      => 'updateable',
 							'desc'    => '',
 							'default' => $this->default_updateable,
@@ -653,14 +653,14 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'salesforce_field_display_value' => array(
-				'title'    => 'Salesforce Field Display Value',
+				'title'    => __( 'Salesforce Field Display Value', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['select'],
 				'page'     => $page,
 				'section'  => $section,
 				'args'     => array(
 					'type'     => 'select',
 					'validate' => 'sanitize_validate_text',
-					'desc'     => 'When choosing Salesforce fields to map, this value determines how the dropdown will identify Salesforce fields.',
+					'desc'     => __( 'When choosing Salesforce fields to map, this value determines how the dropdown will identify Salesforce fields.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 					'items'    => array(
 						'field_label' => array(
@@ -679,7 +679,7 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'pull_query_limit'               => array(
-				'title'    => 'Pull query record limit',
+				'title'    => __( 'Pull query record limit', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page'     => $page,
 				'section'  => $section,
@@ -692,7 +692,7 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'pull_throttle'                  => array(
-				'title'    => 'Pull throttle (seconds)',
+				'title'    => __( 'Pull throttle (seconds)', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page'     => $page,
 				'section'  => $section,
@@ -705,49 +705,49 @@ class Object_Sync_Sf_Admin {
 				),
 			),
 			'use_soap' => array(
-				'title' => 'Enable the Salesforce SOAP API?',
+				'title' => __( 'Enable the Salesforce SOAP API?', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page' => $page,
 				'section' => $section,
 				'args' => array(
-					'type' => 'checkbox',
+					'type'     => 'checkbox',
 					'validate' => 'sanitize_text_field',
-					'desc' => 'Check this to enable the SOAP API and use it instead of the REST API when the plugin supports it. https://developer.salesforce.com/blogs/tech-pubs/2011/10/salesforce-apis-what-they-are-when-to-use-them.html to compare the two. Note: if you need to detect Salesforce merges in this plugin, you will need to enable SOAP.',
+					'desc'     => __( 'Check this to enable the SOAP API and use it instead of the REST API when the plugin supports it. https://developer.salesforce.com/blogs/tech-pubs/2011/10/salesforce-apis-what-they-are-when-to-use-them.html to compare the two. Note: if you need to detect Salesforce merges in this plugin, you will need to enable SOAP.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 				),
 			),
 			'soap_wsdl_path' => array(
-				'title' => 'Path to SOAP WSDL file',
+				'title' => __( 'Path to SOAP WSDL file', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page' => $page,
 				'section' => $section,
 				'args' => array(
-					'type' => 'text',
+					'type'     => 'text',
 					'validate' => 'sanitize_text_field',
-					'desc' => 'Optionally add a path to your own WSDL file. If you do not, the plugin will use the default partner.wsdl.xml from the Force.com toolkit.',
+					'desc'     => __( 'Optionally add a path to your own WSDL file. If you do not, the plugin will use the default partner.wsdl.xml from the Force.com toolkit.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 				),
 			),
 			'debug_mode'                     => array(
-				'title'    => 'Debug mode?',
+				'title'    => __( 'Debug mode?', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page'     => $page,
 				'section'  => $section,
 				'args'     => array(
 					'type'     => 'checkbox',
-					'validate' => 'sanitize_validate_text',
+					'validate' => 'sanitize_text_field',
 					'desc'     => __( 'Debug mode can, combined with the Log Settings, log things like Salesforce API requests. It can create a lot of entries if enabled; it is not recommended to use it in a production environment.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 				),
 			),
 			'delete_data_on_uninstall'       => array(
-				'title'    => 'Delete plugin data on uninstall?',
+				'title'    => __( 'Delete plugin data on uninstall?', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
 				'page'     => $page,
 				'section'  => $section,
 				'args'     => array(
 					'type'     => 'checkbox',
-					'validate' => 'sanitize_validate_text',
+					'validate' => 'sanitize_text_field',
 					'desc'     => __( 'If checked, the plugin will delete the tables and other data it creates when you uninstall it. Unchecking this field can be useful if you need to reactivate the plugin for any reason without losing data.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 				),
@@ -756,13 +756,13 @@ class Object_Sync_Sf_Admin {
 
 		if ( true === is_object( $this->salesforce['sfapi'] ) && true === $this->salesforce['sfapi']->is_authorized() ) {
 			$salesforce_settings['api_version'] = array(
-				'title'    => 'Salesforce API Version',
+				'title'    => __( 'Salesforce API Version', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['select'],
 				'page'     => $page,
 				'section'  => $section,
 				'args'     => array(
 					'type'     => 'select',
-					'validate' => 'sanitize_validate_text',
+					'validate' => 'sanitize_text_field',
 					'desc'     => '',
 					'constant' => 'OBJECT_SYNC_SF_SALESFORCE_API_VERSION',
 					'items'    => $this->version_options(),

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -704,24 +704,24 @@ class Object_Sync_Sf_Admin {
 					'default'  => $this->default_pull_throttle,
 				),
 			),
-			'use_soap' => array(
-				'title' => __( 'Enable the Salesforce SOAP API?', 'object-sync-for-salesforce' ),
+			'use_soap'                       => array(
+				'title'    => __( 'Enable the Salesforce SOAP API?', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
-				'page' => $page,
-				'section' => $section,
-				'args' => array(
+				'page'     => $page,
+				'section'  => $section,
+				'args'     => array(
 					'type'     => 'checkbox',
 					'validate' => 'sanitize_text_field',
 					'desc'     => __( 'Check this to enable the SOAP API and use it instead of the REST API when the plugin supports it. https://developer.salesforce.com/blogs/tech-pubs/2011/10/salesforce-apis-what-they-are-when-to-use-them.html to compare the two. Note: if you need to detect Salesforce merges in this plugin, you will need to enable SOAP.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 				),
 			),
-			'soap_wsdl_path' => array(
-				'title' => __( 'Path to SOAP WSDL file', 'object-sync-for-salesforce' ),
+			'soap_wsdl_path'                 => array(
+				'title'    => __( 'Path to SOAP WSDL file', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['text'],
-				'page' => $page,
-				'section' => $section,
-				'args' => array(
+				'page'     => $page,
+				'section'  => $section,
+				'args'     => array(
 					'type'     => 'text',
 					'validate' => 'sanitize_text_field',
 					'desc'     => __( 'Optionally add a path to your own WSDL file. If you do not, the plugin will use the default partner.wsdl.xml from the Force.com toolkit.', 'object-sync-for-salesforce' ),

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -712,7 +712,7 @@ class Object_Sync_Sf_Admin {
 				'args' => array(
 					'type' => 'checkbox',
 					'validate' => 'sanitize_text_field',
-					'desc' => 'Check this to enable the SOAP API and use it instead of the REST API when the plugin supports it. https://developer.salesforce.com/blogs/tech-pubs/2011/10/salesforce-apis-what-they-are-when-to-use-them.html to compare the two.',
+					'desc' => 'Check this to enable the SOAP API and use it instead of the REST API when the plugin supports it. https://developer.salesforce.com/blogs/tech-pubs/2011/10/salesforce-apis-what-they-are-when-to-use-them.html to compare the two. Note: if you need to detect Salesforce merges in this plugin, you will need to enable SOAP.',
 					'constant' => '',
 				),
 			),
@@ -724,7 +724,7 @@ class Object_Sync_Sf_Admin {
 				'args' => array(
 					'type' => 'text',
 					'validate' => 'sanitize_text_field',
-					'desc' => 'Optionally add the path to your WSDL file. If you do not, the plugin will use the default partner.wsdl.xml from the Force.com toolkit.',
+					'desc' => 'Optionally add a path to your own WSDL file. If you do not, the plugin will use the default partner.wsdl.xml from the Force.com toolkit.',
 					'constant' => '',
 				),
 			),

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -792,10 +792,10 @@ class Object_Sync_Sf_Mapping {
 				// This case means the following:
 				//    this field is expected by the fieldmap
 				//    Salesforce's api reports that this field is required
-				//    we do not have a wordpress value for this field, or it's empty
+				//    we do not have a WordPress value for this field, or it's empty
 				//    it also means the field has not been unset by prematch, updateable, key, or directional flags prior to this check.
 				// When this happens, we should flag that we're missing a required Salesforce field
-				if ( in_array( $salesforce_field, $params) && false === filter_var( $fieldmap['salesforce_field']['nillable'], FILTER_VALIDATE_BOOLEAN ) && ( ! isset( $object[ $wordpress_field ] ) || '' === $object[ $wordpress_field ] ) ) {
+				if ( in_array( $salesforce_field, $params ) && false === filter_var( $fieldmap['salesforce_field']['nillable'], FILTER_VALIDATE_BOOLEAN ) && ( ! isset( $object[ $wordpress_field ] ) || '' === $object[ $wordpress_field ] ) ) {
 					$has_missing_required_salesforce_field = true;
 				}
 
@@ -804,7 +804,7 @@ class Object_Sync_Sf_Mapping {
 
 				// A Salesforce event caused this.
 
-				if ( isset( $salesforce_field_type ) && isset( $object[ $salesforce_field ] )  && ! is_null( $object[ $salesforce_field ] ) ) {
+				if ( isset( $salesforce_field_type ) && isset( $object[ $salesforce_field ] ) && ! is_null( $object[ $salesforce_field ] ) ) {
 					// Salesforce provides multipicklist values as a delimited string. If the
 					// destination field in WordPress accepts multiple values, explode the string into an array and then serialize it.
 					if ( in_array( $salesforce_field_type, $this->array_types_from_salesforce ) ) {

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -108,7 +108,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		// action-scheduler needs two hooks: one to check for records, and one to process them
 		add_action( $this->option_prefix . 'pull_check_records', array( $this, 'salesforce_pull' ), 10 );
-		add_action( $this->option_prefix . 'pull_process_records', array( $this, 'salesforce_pull_process_records' ), 10, 4 );
+		add_action( $this->option_prefix . 'pull_process_records', array( $this, 'salesforce_pull_process_records' ), 10, 3 );
 	}
 
 	/**
@@ -262,7 +262,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$debug = array(
 					'title'   => $title,
 					'message' => esc_html( (string) $soql ),
-					'trigger' => $salesforce_mapping['sync_triggers'],
+					'trigger' => 0,
 					'parent'  => '',
 					'status'  => $status,
 				);
@@ -305,7 +305,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							$debug = array(
 								'title'   => $title,
 								'message' => esc_html__( 'This ID has already been attempted so it was not pulled again.', 'object-sync-for-salesforce' ),
-								'trigger' => $salesforce_mapping['sync_triggers'],
+								'trigger' => 0,
 								'parent'  => '',
 								'status'  => $status,
 							);
@@ -379,8 +379,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 							}
 
-							$message = sprintf(
-								esc_html__( 'This record is being sent to the queue. The hook name is %1$s. The arguments for the hook are: object type %2$s, object map ID %3$s, sync trigger %4$s. The schedule name is %5$s.', 'object-sync-for-salesforce' ),
+							// translators: placeholders are 1) the hook name, 2) the Salesforce object type, 3) the object map ID, 4) the sync trigger, 5) the schedule name.
+							$message = sprintf( esc_html__( 'This record is being sent to the queue. The hook name is %1$s. The arguments for the hook are: object type %2$s, object map ID %3$s, sync trigger %4$s. The schedule name is %5$s.', 'object-sync-for-salesforce' ),
 								esc_attr( $this->schedulable_classes[ $this->schedule_name ]['callback'] ),
 								esc_attr( $type ),
 								absint( $salesforce_mapping['id'] ),
@@ -405,7 +405,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 							array(
 								'object_type'     => $type,
 								'object'          => $result['Id'],
-								'mapping'         => filter_var( $salesforce_mapping['id'], FILTER_VALIDATE_INT ),
 								'sf_sync_trigger' => $sf_sync_trigger,
 							),
 							$this->schedule_name
@@ -413,7 +412,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						// update the current state so we don't end up on the same record again if the loop fails
 						update_option( $this->option_prefix . 'last_pull_id', $result['Id'] );
 						if ( 1 === (int) $this->debug ) {
-							// create log entry for failed pull
+							// create log entry for successful pull
 							$status = 'debug';
 							// translators: placeholders are: 1) the Salesforce ID
 							$title = sprintf( esc_html__( 'Debug: Salesforce ID %1$s has been successfully pulled.', 'object-sync-for-salesforce' ),
@@ -428,7 +427,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 							$debug = array(
 								'title'   => $title,
-								'message' => esc_html__( 'This ID has been successfully pulled. It cannot be pulled again.', 'object-sync-for-salesforce' ),
+								'message' => esc_html__( 'This ID has been successfully pulled and added to the queue for processing. It cannot be pulled again without being modified again.', 'object-sync-for-salesforce' ),
 								'trigger' => $sf_sync_trigger,
 								'parent'  => '',
 								'status'  => $status,
@@ -485,7 +484,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$result = array(
 					'title'   => $title,
 					'message' => $response['message'],
-					'trigger' => $salesforce_mapping['sync_triggers'],
+					'trigger' => 0,
 					'parent'  => '',
 					'status'  => $status,
 				);
@@ -549,7 +548,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 							array(
 								'object_type'     => $type,
 								'object'          => $result['Id'],
-								'mapping'         => filter_var( $salesforce_mapping['id'], FILTER_VALIDATE_INT ),
 								'sf_sync_trigger' => $sf_sync_trigger,
 							),
 							$this->schedule_name
@@ -631,19 +629,19 @@ class Object_Sync_Sf_Salesforce_Pull {
 		);
 
 		// Iterate over each field mapping to determine our query parameters.
-		foreach ( $mappings as $mapping ) {
+		foreach ( $mappings as $salesforce_mapping ) {
 
 			// only use fields that come from Salesforce to WordPress, or that sync
 			$mapped_fields = array_merge(
 				$mapped_fields,
 				$this->mappings->get_mapped_fields(
-					$mapping,
+					$salesforce_mapping,
 					array( $this->mappings->direction_sync, $this->mappings->direction_sf_wordpress )
 				)
 			);
 
 			// If Record Type is specified, restrict query.
-			$mapping_record_types = $this->mappings->get_mapped_record_types( $mapping );
+			$mapping_record_types = $this->mappings->get_mapped_record_types( $salesforce_mapping );
 
 			// If Record Type is not specified for a given mapping, ensure query is unrestricted.
 			if ( empty( $mapping_record_types ) ) {
@@ -828,7 +826,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$merged = array();
 				// there doesn't appear to be a way to do this in the rest api; for now we'll do soap
 				if ( true === $use_soap ) {
-					$type = $salesforce_mapping['salesforce_object'];
+					$type   = $salesforce_mapping['salesforce_object'];
 					$query  = "SELECT Id, isDeleted, masterRecordId FROM $type WHERE masterRecordId != '' AND SystemModStamp > $last_merge_sync_sf";
 					$merged = $soap->try_soap( 'queryAll', $query );
 					if ( ! empty( $merged->records ) ) {
@@ -930,7 +928,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		// We are not incorporating that part of this branch at this time
 		// See GitHub issue 197 to track this status. https://github.com/MinnPost/object-sync-for-salesforce/issues/197
 
-		// Load all unique SF record types that we have mappings for.
+		// Load all unique SF record types that we have mappings for. This results in a double loop.
 		foreach ( $this->mappings->get_fieldmaps() as $salesforce_mapping ) {
 
 			$map_sync_triggers = $salesforce_mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping
@@ -944,7 +942,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			);
 
 			// Iterate over each field mapping to determine our query parameters.
-			foreach ( $mappings as $mapping ) {
+			foreach ( $mappings as $salesforce_mapping ) {
 
 				$last_delete_sync = get_option( $this->option_prefix . 'pull_delete_last_' . $type, current_time( 'timestamp', true ) );
 				$now              = current_time( 'timestamp', true );
@@ -994,7 +992,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$data = array(
 						'object_type'     => $type,
 						'object'          => $result,
-						'mapping'         => $mapping,
+						'mapping'         => $salesforce_mapping,
 						'sf_sync_trigger' => $sf_sync_trigger, // sf delete trigger
 					);
 
@@ -1025,13 +1023,18 @@ class Object_Sync_Sf_Salesforce_Pull {
 						continue;
 					}
 
+					// setup the Id and the deletedDate for passing to the queue
+					$deleted_item = array(
+						'Id'          => $result['Id'],
+						'deletedDate' => $result['deletedDate'],
+					);
+
 					// Add a queue action to delete data from WordPress after it has been deleted from Salesforce.
 					$this->queue->add(
 						$this->schedulable_classes[ $this->schedule_name ]['callback'],
 						array(
 							'object_type'     => $type,
-							'object'          => $result['Id'],
-							'mapping'         => filter_var( $salesforce_mapping['id'], FILTER_VALIDATE_INT ),
+							'object'          => $deleted_item,
 							'sf_sync_trigger' => $sf_sync_trigger,
 						),
 						$this->schedule_name
@@ -1085,9 +1088,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			$results = array();
 
-			foreach ( $salesforce_mappings as $mapping ) {
+			foreach ( $salesforce_mappings as $salesforce_mapping ) {
 
-				$map_sync_triggers = $mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping
+				$map_sync_triggers = $salesforce_mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping
 
 				// If no lastupdate, get all records, else get records since last pull.
 				// this should be what keeps it from getting all the records, whether or not they've ever been updated
@@ -1107,10 +1110,10 @@ class Object_Sync_Sf_Salesforce_Pull {
 				} else {
 					$sf_sync_trigger = $this->mappings->sync_sf_update;
 				}
-				$pull_allowed = $this->is_pull_allowed( $object_type, $object, $sf_sync_trigger, $mapping, $map_sync_triggers );
+				$pull_allowed = $this->is_pull_allowed( $object_type, $object, $sf_sync_trigger, $salesforce_mapping, $map_sync_triggers );
 
 				if ( true === $pull_allowed ) {
-					$result = $this->salesforce_pull_process_records( $object_type, $object, $mapping, $sf_sync_trigger );
+					$result = $this->salesforce_pull_process_records( $object_type, $object, $sf_sync_trigger );
 				} else {
 					$status = 'error';
 					// create log entry for not allowed manual pull
@@ -1122,8 +1125,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					// translators: placeholders are: 1) the name of the WordPress object type, 2) the name of the Salesforce object, 3) the Salesforce Id value
 					$title = sprintf( esc_html__( 'Error: Manually pull WordPress %1$s not allowed (%2$s %3$s)', 'object-sync-for-salesforce' ),
-						esc_attr( $mapping['wordpress_object'] ),
-						esc_attr( $mapping['salesforce_object'] ),
+						esc_attr( $salesforce_mapping['wordpress_object'] ),
+						esc_attr( $salesforce_mapping['salesforce_object'] ),
 						esc_attr( $salesforce_id )
 					);
 
@@ -1185,40 +1188,56 @@ class Object_Sync_Sf_Salesforce_Pull {
 	*   Type of Salesforce object.
 	* @param array|string $object
 	*   The Salesforce data or its Id value.
-	* @param array|int $mapping
-	*   Salesforce/WP mapping data or its id.
 	* @param int $sf_sync_trigger
 	*   Trigger for this sync.
 	*
 	* @return true or exit the method
 	*
 	*/
-	public function salesforce_pull_process_records( $object_type, $object, $mapping, $sf_sync_trigger ) {
+	public function salesforce_pull_process_records( $object_type, $object, $sf_sync_trigger ) {
 
 		$sfapi = $this->salesforce['sfapi'];
 
 		if ( is_string( $object ) ) {
-			$object_id = $object;
+			$salesforce_id = $object;
 			// Load the Salesforce object data to save in WordPress. We need to make sure that this data does not get cached, which is consistent with other pull behavior as well as in other methods in this class.
 			// We should only do this if we're not trying to delete data in WordPress - otherwise, we'll get a 404 from Salesforce and the delete will fail.
 			if ( $sf_sync_trigger != $this->mappings->sync_sf_delete ) { // trigger is a bit operator
 				$object = $sfapi->object_read(
 					$object_type,
-					$object_id,
+					$salesforce_id,
 					array(
 						'cache' => false,
 					)
 				)['data'];
 			} else {
-				$object = array(
-					'Id' => $object,
-				);
-			} // gently handle deleted records
-		}
+				if ( 1 === (int) $this->debug ) {
+					// create log entry for failed pull
+					$status = 'debug';
+					$title  = esc_html__( 'Debug: we are missing a deletedDate attribute here, but are expected to delete an item.', 'object-sync-for-salesforce' );
 
-		if ( is_int( $mapping ) ) {
-			$mapping_id = $mapping;
-			$mapping    = $this->mappings->get_fieldmaps( $mapping_id );
+					if ( isset( $this->logging ) ) {
+						$logging = $this->logging;
+					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+					}
+
+					$debug = array(
+						'title'   => $title,
+						'message' => '',
+						'trigger' => $sf_sync_trigger,
+						'parent'  => '',
+						'status'  => $status,
+					);
+
+					$logging->setup( $debug );
+				}
+
+				$object = array(
+					'Id'          => $object,
+					'deletedDate' => gmdate( 'Y-m-d\TH:i:s\Z' ), // this should hopefully never happen
+				);
+			} // deleted records should always come through with their own deletedDate value
 		}
 
 		$mapping_conditions = array(
@@ -1246,8 +1265,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 		foreach ( $salesforce_mappings as $salesforce_mapping ) {
 
 			// this returns the row that maps the individual Salesforce row to the individual WordPress row
+			// todo: this is where we'd start to address issue #135. we'd have to loop through mapping_objects if any existed.
 			if ( isset( $object['Id'] ) ) {
-				$mapping_object = $this->mappings->load_by_salesforce( $object['Id'] );
+				$mapping_objects = $this->mappings->load_all_by_salesforce( $object['Id'] );
 			} else {
 				// if we don't have a Salesforce object id, we've got no business doing stuff in WordPress
 				$status = 'error';
@@ -1273,44 +1293,28 @@ class Object_Sync_Sf_Salesforce_Pull {
 				continue;
 			}
 
-			// if there's already a connection between the objects, $mapping_object will be an array
-			// if it's not already connected (ie on create), the array will be empty
-
-			// hook to allow other plugins to define or alter the mapping object
-			$mapping_object = apply_filters( $this->option_prefix . 'pull_mapping_object', $mapping_object, $object, $mapping );
-
-			// we already have the data from Salesforce at this point; we just need to work with it in WordPress
-			$synced_object = array(
-				'salesforce_object' => $object,
-				'mapping_object'    => $mapping_object,
-				'mapping'           => $mapping,
-			);
-
-			$structure = $this->wordpress->get_wordpress_table_structure( $salesforce_mapping['wordpress_object'] );
-			$object_id = $structure['id_field'];
-
-			$op = '';
-
-			// are these objects already connected in WordPress?
-			if ( isset( $mapping_object['id'] ) ) {
-				$is_new                      = false;
-				$mapping_object_id_transient = $mapping_object['id'];
+			// Is this Salesforce object already connected to at least one WordPress object?
+			if ( isset( $mapping_objects[0]['id'] ) ) {
+				$is_new = false;
 			} else {
-				// there is not a mapping object for this WordPress object id yet
-				// check for that transient with the currently pushing id
-				$is_new                      = true;
-				$mapping_object_id_transient = get_transient( 'salesforce_pushing_object_id' );
+				// there is not a mapping object for this Salesforce object id yet
+				// check to see if there is a pushing transient for that Salesforce Id
+				$is_new = true;
 			}
 
+			$mapping_object_id_transient = get_transient( 'salesforce_pushing_object_id' );
+			if ( false === $mapping_object_id_transient ) {
+				$mapping_object_id_transient = $object['Id'];
+			}
 			// Here's where we check to see whether the current record was updated by a push from this plugin or not. Here's how it works:
 			// 1. A record gets pushed to Salesforce by this plugin.
 			// 2. We save the LastModifiedDate from the Salesforce result as a timestamp in the transient.
-			// 3. Below, in addition to checking the record Id, we check against $object's LastModifiedDate and if it's not later than the transient value, we skip it because it's still pushing from our activity.
-			$salesforce_pushing = get_transient( 'salesforce_pushing_' . $mapping_object_id_transient );
+			// 3. Below, in addition to checking the Salesforce Id, we check against $object's LastModifiedDate and if it's not later than the transient value, we skip it because it's still pushing from our activity.
+			$salesforce_pushing = (int) get_transient( 'salesforce_pushing_' . $mapping_object_id_transient );
 
-			if ( '1' !== $salesforce_pushing ) {
-				//$salesforce_pushing = gmdate( 'Y-m-d\TH:i:s\Z', $salesforce_pushing );
-				if ( false === $salesforce_pushing || strtotime( $object['LastModifiedDate'] ) > $salesforce_pushing ) {
+			if ( 1 !== $salesforce_pushing ) {
+				// the format to compare is like this: gmdate( 'Y-m-d\TH:i:s\Z', $salesforce_pushing )
+				if ( 0 === $salesforce_pushing || ( isset( $object['LastModifiedDate'] ) && strtotime( $object['LastModifiedDate'] ) > $salesforce_pushing ) || ( isset( $object['deletedDate'] ) && strtotime( $object['deletedDate'] ) > $salesforce_pushing ) ) {
 					$salesforce_pushing = 0;
 				} else {
 					$salesforce_pushing = 1;
@@ -1338,7 +1342,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$debug = array(
 						'title'   => $title,
 						'message' => '',
-						'trigger' => $salesforce_mapping['sync_triggers'],
+						'trigger' => $sf_sync_trigger,
 						'parent'  => '',
 						'status'  => $status,
 					);
@@ -1349,403 +1353,286 @@ class Object_Sync_Sf_Salesforce_Pull {
 				continue;
 			}
 
-			// deleting mapped objects
-			if ( $sf_sync_trigger == $this->mappings->sync_sf_delete ) { // trigger is a bit operator
-				if ( isset( $mapping_object['id'] ) ) {
+			$structure               = $this->wordpress->get_wordpress_table_structure( $salesforce_mapping['wordpress_object'] );
+			$wordpress_id_field_name = $structure['id_field'];
 
-					set_transient( 'salesforce_pulling_' . $mapping_object['id'], 1, $seconds );
-					set_transient( 'salesforce_pulling_object_id', $mapping_object['id'] );
+			// don't do parameters if we are deleting
+			if ( true === $is_new || $sf_sync_trigger == $this->mappings->sync_sf_create || $sf_sync_trigger == $this->mappings->sync_sf_update ) { // trigger is a bit operator
 
-					$op              = 'Delete';
-					$wordpress_check = $this->mappings->load_by_wordpress( $mapping_object['wordpress_object'], $mapping_object['wordpress_id'] );
-					if ( count( $wordpress_check ) === count( $wordpress_check, COUNT_RECURSIVE ) ) {
-						try {
-							$result = $this->wordpress->object_delete( $salesforce_mapping['wordpress_object'], $mapping_object['wordpress_id'] );
-						} catch ( WordpressException $e ) {
-							$status = 'error';
-							// create log entry for failed delete
-							if ( isset( $this->logging ) ) {
-								$logging = $this->logging;
-							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-							}
+				// map the Salesforce values to WordPress fields
+				$params = $this->mappings->map_params( $salesforce_mapping, $object, $sf_sync_trigger, false, $is_new, $wordpress_id_field_name );
 
-							// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-							$title = sprintf( esc_html__( 'Error: %1$s WordPress %2$s with %3$s of %4$s (%5$s %6$s)', 'object-sync-for-salesforce' ),
-								esc_attr( $op ),
-								esc_attr( $salesforce_mapping['wordpress_object'] ),
-								esc_attr( $object_id ),
-								esc_attr( $mapping_object['wordpress_id'] ),
-								esc_attr( $salesforce_mapping['salesforce_object'] ),
-								esc_attr( $mapping_object['salesforce_id'] )
-							);
+				// hook to allow other plugins to modify the $params array
+				// use hook to map fields between the WordPress and Salesforce objects
+				// returns $params.
+				$params = apply_filters( $this->option_prefix . 'pull_params_modify', $params, $salesforce_mapping, $object, $sf_sync_trigger, false, $is_new );
 
-							$result = array(
-								'title'   => $title,
-								'message' => $e->getMessage(),
-								'trigger' => $sf_sync_trigger,
-								'parent'  => $mapping_object['wordpress_id'],
-								'status'  => $status,
-							);
+				// setup prematch parameters
+				$prematch = array();
 
-							$logging->setup( $result );
+				// if there is a prematch WordPress field - ie email - on the fieldmap object
+				if ( isset( $params['prematch'] ) && is_array( $params['prematch'] ) ) {
+					$prematch['field_wordpress']  = $params['prematch']['wordpress_field'];
+					$prematch['field_salesforce'] = $params['prematch']['salesforce_field'];
+					$prematch['value']            = $params['prematch']['value'];
+					$prematch['methods']          = array(
+						'method_match'  => isset( $params['prematch']['method_match'] ) ? $params['prematch']['method_match'] : $params['prematch']['method_read'],
+						'method_create' => $params['prematch']['method_create'],
+						'method_update' => $params['prematch']['method_update'],
+						'method_read'   => $params['prematch']['method_read'],
+					);
+					unset( $params['prematch'] );
+				}
 
-							$results[] = $result;
+				// if there is an external key field in Salesforce - ie a Mailchimp user id - on the fieldmap object, this should not affect how WordPress handles it is not included in the pull parameters.
 
-							if ( false === $hold_exceptions ) {
-								throw $e;
-							}
-							if ( empty( $exception ) ) {
-								$exception = $e;
-							} else {
-								$my_class  = get_class( $e );
-								$exception = new $my_class( $e->getMessage(), $e->getCode(), $exception );
-							}
+				// if we don't get any params, there are no fields that should be sent to WordPress
+				if ( empty( $params ) ) {
+					return;
+				}
+			} // end checking for create/update
 
-							// hook for pull fail
-							do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
+			// if this Salesforce record is new to WordPress, we can try to create it
+			if ( true === $is_new ) {
+				if ( isset( $mapping_objects[0] ) ) {
+					$mapping_object = $mapping_objects[0];
+				} else {
+					$mapping_object = $mapping_objects;
+				}
+				$synced_object = $this->get_synced_object( $object, $mapping_object, $salesforce_mapping );
+				$create        = $this->create_called_from_salesforce( $sf_sync_trigger, $synced_object, $params, $prematch, $wordpress_id_field_name, $seconds );
+			} elseif ( false === $is_new ) {
+				// there is already at least one mapping_object['id'] associated with this Salesforce Id
+				// right here we should set the pulling transient
+				set_transient( 'salesforce_pulling_' . $mapping_objects[0]['salesforce_id'], 1, $seconds );
+				set_transient( 'salesforce_pulling_object_id', $mapping_objects[0]['salesforce_id'] );
 
-						} // End try().
-
-						if ( ! isset( $e ) ) {
-							// create log entry for successful delete if the result had no errors
-							$status = 'success';
-							if ( isset( $this->logging ) ) {
-								$logging = $this->logging;
-							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-							}
-
-							// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-							$title = sprintf( esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (%5$s %6$s)', 'object-sync-for-salesforce' ),
-								esc_attr( $op ),
-								esc_attr( $salesforce_mapping['wordpress_object'] ),
-								esc_attr( $object_id ),
-								esc_attr( $mapping_object['wordpress_id'] ),
-								esc_attr( $salesforce_mapping['salesforce_object'] ),
-								esc_attr( $mapping_object['salesforce_id'] )
-							);
-
-							$result = array(
-								'title'   => $title,
-								'message' => '',
-								'trigger' => $sf_sync_trigger,
-								'parent'  => $mapping_object['wordpress_id'],
-								'status'  => $status,
-							);
-
-							$logging->setup( $result );
-
-							$results[] = $result;
-
-							// hook for pull success
-							do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
-						}
+				foreach ( $mapping_objects as $mapping_object ) {
+					$synced_object = $this->get_synced_object( $object, $mapping_object, $salesforce_mapping );
+					// if params is set, this is an update request. if not, it is a delete.
+					if ( isset( $params ) ) {
+						$update = $this->update_called_from_salesforce( $sf_sync_trigger, $synced_object, $params, $wordpress_id_field_name, $seconds );
 					} else {
-						$more_ids = sprintf( '<p>' . esc_html__( 'The WordPress record was not deleted because there are multiple Salesforce IDs that match this WordPress ID. They are:', 'object-sync-for-salesforce' ) );
-						$i        = 0;
-						foreach ( $wordpress_check as $match ) {
-							$i++;
-							$more_ids .= sprintf( $match['salesforce_id'] );
-							if ( count( $wordpress_check ) !== $i ) {
-								$more_ids .= sprintf( ', ' );
-							} else {
-								$more_ids .= sprintf( '.</p>' );
+						$delete = $this->delete_called_from_salesforce( $sf_sync_trigger, $synced_object, $wordpress_id_field_name, $seconds );
+					}
+				}
+			}
+		} // End foreach() on $salesforce_mappings.
+
+		// delete transients that we've already processed for this Salesforce object.
+		foreach ( $transients_to_delete as $mapping_object_id_transient ) {
+			delete_transient( 'salesforce_pushing_' . $mapping_object_id_transient );
+		}
+
+		$pushing_id = get_transient( 'salesforce_pushing_object_id' );
+		if ( in_array( $pushing_id, $transients_to_delete, true ) ) {
+			delete_transient( 'salesforce_pushing_object_id' );
+		}
+
+		if ( ! empty( $exception ) ) {
+			throw $exception;
+		}
+
+		return $results;
+
+	}
+
+	/**
+	* Generate the synced_object array
+	*
+	* @param array $object
+	*   The data for the Salesforce object
+	* @param array $mapping_object
+	*   The data for the mapping object between the individual Salesforce and WordPress items
+	* @param array $salesforce_mapping
+	*   The data for the fieldmap between the object types
+	* @return array $synced_object
+	*   The combined array of these items. It allows for filtering of, at least, the mapping_object.
+	*
+	*/
+	private function get_synced_object( $object, $mapping_object, $salesforce_mapping ) {
+		// if there's already a connection between the objects, $mapping_object will be an array at this point
+		// if it's not already connected (ie on create), the array will be empty
+
+		// hook to allow other plugins to define or alter the mapping object
+		$mapping_object = apply_filters( $this->option_prefix . 'pull_mapping_object', $mapping_object, $object, $salesforce_mapping );
+
+		// we already have the data from Salesforce at this point; we just need to work with it in WordPress
+		$synced_object = array(
+			'salesforce_object' => $object,
+			'mapping_object'    => $mapping_object,
+			'mapping'           => $salesforce_mapping,
+		);
+		return $synced_object;
+	}
+
+	/**
+	* Create records in WordPress from a Salesforce pull
+	*
+	* @param string $sf_sync_trigger
+	*   The current operation's trigger
+	* @param array $synced_object
+	*   Combined data for fieldmap, mapping object, and Salesforce object data
+	* @param array $params
+	*   Array of mapped key value pairs between WordPress and Salesforce fields.
+	* @param array $prematch
+	*   Array of criteria to determine what to do on upsert operations
+	* @param string $wordpress_id_field_name
+	*   The name of the ID field for this particular WordPress object type
+	* @param int $seconds
+	*   Timeout for the transient value to determine the direction for a sync.
+	* @return array $results
+	*   Currently this contains an array of log entries for each attempt.
+	*
+	*/
+	private function create_called_from_salesforce( $sf_sync_trigger, $synced_object, $params, $prematch, $wordpress_id_field_name, $seconds ) {
+
+		$salesforce_mapping = $synced_object['mapping'];
+		$object             = $synced_object['salesforce_object'];
+		// methods to run the wp update operations
+		$results = array();
+		$op      = '';
+
+		// setup SF record type. CampaignMember objects get their Campaign's type
+		// i am still a bit confused about this
+		// we should store this as a meta field on each object, if it meets these criteria
+		// we need to store the read/modify attributes because the field doesn't exist in the mapping
+		if ( $salesforce_mapping['salesforce_record_type_default'] !== $this->mappings->salesforce_default_record_type && empty( $params['RecordTypeId'] ) && ( 'CampaignMember' !== $salesforce_mapping['salesforce_object'] ) ) {
+			$type = $salesforce_mapping['wordpress_object'];
+			if ( 'category' === $salesforce_mapping['wordpress_object'] || 'tag' === $salesforce_mapping['wordpress_object'] || 'post_tag' === $salesforce_mapping['wordpress_object'] ) {
+				$type = 'term';
+			}
+			$params['RecordTypeId'] = array(
+				'value'         => $salesforce_mapping['salesforce_record_type_default'],
+				'method_modify' => 'update_' . $type . '_meta',
+				'method_read'   => 'get_' . $type . '_meta',
+			);
+		}
+
+		try {
+
+			// hook to allow other plugins to modify the $wordpress_id string here
+			// use hook to change the object that is being matched to developer's own criteria
+			// ex: match a WordPress user based on some other criteria than the predefined ones
+			// returns a $wordpress_id.
+			// it should keep NULL if there is no match
+			// the function that calls this hook needs to check the mapping to make sure the WordPress object is the right type
+			$wordpress_id = apply_filters( $this->option_prefix . 'find_wp_object_match', null, $object, $salesforce_mapping, 'pull' );
+
+			// hook to allow other plugins to do something right before WordPress data is saved
+			// ex: run outside methods on an object if it exists, or do something in preparation for it if it doesn't
+			do_action( $this->option_prefix . 'pre_pull', $wordpress_id, $salesforce_mapping, $object, $wordpress_id_field_name, $params );
+
+			if ( isset( $prematch['field_salesforce'] ) || null !== $wordpress_id ) {
+
+				$op = 'Upsert';
+
+				// if a prematch criteria exists, make the values queryable
+				if ( isset( $prematch['field_salesforce'] ) ) {
+					$upsert_key     = $prematch['field_wordpress'];
+					$upsert_value   = $prematch['value'];
+					$upsert_methods = $prematch['methods'];
+				}
+
+				if ( null !== $wordpress_id ) {
+					$upsert_key     = $wordpress_id_field_name;
+					$upsert_value   = $wordpress_id;
+					$upsert_methods = array();
+				}
+
+				// with the flag at the end, upsert returns a $wordpress_id only
+				// we can then check to see if it has a mapping object
+				// we should only do this if the above hook didn't already set the $wordpress_id
+				if ( null === $wordpress_id ) {
+					$wordpress_id = $this->wordpress->object_upsert( $salesforce_mapping['wordpress_object'], $upsert_key, $upsert_value, $upsert_methods, $params, $salesforce_mapping['pull_to_drafts'], true );
+				}
+
+				// find out if there is a mapping object for this WordPress object already
+				// don't do it if the WordPress id is 0.
+				if ( 0 !== $wordpress_id ) {
+					$mapping_object = $this->mappings->get_object_maps(
+						array(
+							'wordpress_id'     => $wordpress_id,
+							'wordpress_object' => $salesforce_mapping['wordpress_object'],
+						)
+					);
+				} else {
+					// if the wp object is 0, check to see if there are any object maps that have an id of 0. if there are any, log them.
+					$mapping_object_debug = $this->mappings->get_object_maps(
+						array(
+							'wordpress_id' => $wordpress_id,
+						)
+					);
+
+					if ( array() !== $mapping_object_debug ) {
+						// create log entry to warn about at least one id of 0
+						$status = 'error';
+						$title  = sprintf( esc_html__( 'Error: There is at least one object map with a WordPress ID of 0.', 'object-sync-for-salesforce' ) );
+
+						if ( 1 === count( $mapping_object_debug ) ) {
+							// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the Salesforce object it was trying to map
+							$body = sprintf( esc_html__( 'There is an object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of 0 and the Salesforce object with ID of %3$s', 'object-sync-for-salesforce' ),
+								absint( $mapping_object_debug['id'] ),
+								esc_attr( $salesforce_mapping['wordpress_object'] ),
+								esc_attr( $mapping_object_debug['salesforce_id'] )
+							);
+						} else {
+							$body = sprintf( esc_html__( 'There are multiple object maps with WordPress ID of 0. Their IDs are: ', 'object-sync-for-salesforce' ) . '<ul>' );
+							foreach ( $mapping_object_debug as $mapping_object ) {
+								// translators: placeholders are: 1) the mapping object row ID, 2) the ID of the Salesforce object, 3) the WordPress object type
+								$body .= sprintf( '<li>' . esc_html__( 'Mapping object id: %1$s. Salesforce Id: %2$s. WordPress object type: %3$s', 'object-sync-for-salesforce' ) . '</li>',
+									absint( $mapping_object['id'] ),
+									esc_attr( $mapping_object['salesforce_id'] ),
+									esc_attr( $salesforce_mapping['wordpress_object'] )
+								);
 							}
+							$body .= sprintf( '</ul>' );
 						}
 
-						$more_ids .= sprintf( '<p>' . esc_html__( 'The map row between this Salesforce object and the WordPress object, as stored in the WordPress database, will be deleted, and this Salesforce object has been deleted, but the WordPress object row will remain untouched.', 'object-sync-for-salesforce' ) . '</p>' );
-
-						$status = 'notice';
 						if ( isset( $this->logging ) ) {
 							$logging = $this->logging;
 						} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 							$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 						}
-
-						// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-						$title = sprintf( esc_html__( 'Notice: %1$s %2$s with %3$s of %4$s (%5$s %6$s) did not delete the WordPress item.', 'object-sync-for-salesforce' ),
-							esc_attr( $op ),
-							esc_attr( $salesforce_mapping['wordpress_object'] ),
-							esc_attr( $object_id ),
-							esc_attr( $mapping_object['wordpress_id'] ),
-							esc_attr( $salesforce_mapping['salesforce_object'] ),
-							esc_attr( $mapping_object['salesforce_id'] )
-						);
+						$parent = 0;
 
 						$result = array(
 							'title'   => $title,
-							'message' => $more_ids,
+							'message' => $body,
 							'trigger' => $sf_sync_trigger,
-							'parent'  => $mapping_object['wordpress_id'],
+							'parent'  => $parent,
 							'status'  => $status,
 						);
 
 						$logging->setup( $result );
 
 						$results[] = $result;
-
 					} // End if().
-
-					// delete the map row from WordPress after the WordPress row has been deleted
-					// we delete the map row even if the WordPress delete failed, because the Salesforce object is gone
-					$this->mappings->delete_object_map( $mapping_object['id'] );
-					// there is no map row if we end this if statement
 				} // End if().
-				continue;
-			} // End if().
 
-			// map the Salesforce values to WordPress fields
-			$params = $this->mappings->map_params( $mapping, $object, $sf_sync_trigger, false, $is_new );
-
-			// hook to allow other plugins to modify the $params array
-			// use hook to map fields between the WordPress and Salesforce objects
-			// returns $params.
-			$params = apply_filters( $this->option_prefix . 'pull_params_modify', $params, $mapping, $object, $sf_sync_trigger, false, $is_new );
-
-			// if we don't get any params, there are no fields that should be sent to WordPress
-			if ( empty( $params ) ) {
-				return;
-			}
-
-			// if there is a prematch WordPress field - ie email - on the fieldmap object
-			if ( isset( $params['prematch'] ) && is_array( $params['prematch'] ) ) {
-				$prematch_field_wordpress  = $params['prematch']['wordpress_field'];
-				$prematch_field_salesforce = $params['prematch']['salesforce_field'];
-				$prematch_value            = $params['prematch']['value'];
-				$prematch_methods          = array(
-					'method_match'  => isset( $params['prematch']['method_match'] ) ? $params['prematch']['method_match'] : $params['prematch']['method_read'],
-					'method_create' => $params['prematch']['method_create'],
-					'method_update' => $params['prematch']['method_update'],
-					'method_read'   => $params['prematch']['method_read'],
-				);
-				unset( $params['prematch'] );
-			}
-
-			// if there is an external key field in Salesforce - ie a Mailchimp user id - on the fieldmap object, this should not affect how WordPress handles it so we have removed it from the pull parameters.
-
-			// methods to run the wp create or update operations
-
-			if ( true === $is_new ) {
-
-				// setup SF record type. CampaignMember objects get their Campaign's type
-				// i am still a bit confused about this
-				// we should store this as a meta field on each object, if it meets these criteria
-				// we need to store the read/modify attributes because the field doesn't exist in the mapping
-				if ( $salesforce_mapping['salesforce_record_type_default'] !== $this->mappings->salesforce_default_record_type && empty( $params['RecordTypeId'] ) && ( 'CampaignMember' !== $salesforce_mapping['salesforce_object'] ) ) {
-					$type = $salesforce_mapping['wordpress_object'];
-					if ( 'category' === $salesforce_mapping['wordpress_object'] || 'tag' === $salesforce_mapping['wordpress_object'] || 'post_tag' === $salesforce_mapping['wordpress_object'] ) {
-						$type = 'term';
-					}
-					$params['RecordTypeId'] = array(
-						'value'         => $salesforce_mapping['salesforce_record_type_default'],
-						'method_modify' => 'update_' . $type . '_meta',
-						'method_read'   => 'get_' . $type . '_meta',
-					);
-				}
-
-				try {
-
-					// hook to allow other plugins to modify the $salesforce_id string here
-					// use hook to change the object that is being matched to developer's own criteria
-					// ex: match a WordPress user based on some other criteria than the predefined ones
-					// returns a $salesforce_id.
-					// it should keep NULL if there is no match
-					// the function that calls this hook needs to check the mapping to make sure the WordPress object is the right type
-					$wordpress_id = apply_filters( $this->option_prefix . 'find_wp_object_match', null, $object, $mapping, 'pull' );
-
-					// hook to allow other plugins to do something right before WordPress data is saved
-					// ex: run outside methods on an object if it exists, or do something in preparation for it if it doesn't
-					do_action( $this->option_prefix . 'pre_pull', $wordpress_id, $mapping, $object, $object_id, $params );
-
-					if ( isset( $prematch_field_salesforce ) || null !== $wordpress_id ) {
-
-						$op = 'Upsert';
-
-						// if a prematch criteria exists, make the values queryable
-						if ( isset( $prematch_field_salesforce ) ) {
-							$upsert_key     = $prematch_field_wordpress;
-							$upsert_value   = $prematch_value;
-							$upsert_methods = $prematch_methods;
-						}
-
-						if ( null !== $wordpress_id ) {
-							$upsert_key     = $object_id;
-							$upsert_value   = $wordpress_id;
-							$upsert_methods = array();
-						}
-
-						// with the flag at the end, upsert returns a $wordpress_id only
-						// we can then check to see if it has a mapping object
-						// we should only do this if the above hook didn't already set the $wordpress_id
-						if ( null === $wordpress_id ) {
-							$wordpress_id = $this->wordpress->object_upsert( $salesforce_mapping['wordpress_object'], $upsert_key, $upsert_value, $upsert_methods, $params, $salesforce_mapping['pull_to_drafts'], true );
-						}
-
-						// find out if there is a mapping object for this WordPress object already
-						// don't do it if the WordPress id is 0.
-						if ( 0 !== $wordpress_id ) {
-							$mapping_object = $this->mappings->get_object_maps(
-								array(
-									'wordpress_id'     => $wordpress_id,
-									'wordpress_object' => $salesforce_mapping['wordpress_object'],
-								)
-							);
-						} else {
-							// if the wp object is 0, check to see if there are any object maps that have an id of 0. if there are any, log them.
-							$mapping_object_debug = $this->mappings->get_object_maps(
-								array(
-									'wordpress_id' => $wordpress_id,
-								)
-							);
-
-							if ( array() !== $mapping_object_debug ) {
-								// create log entry to warn about at least one id of 0
-								$status = 'error';
-								$title  = sprintf( esc_html__( 'Error: There is at least one object map with a WordPress ID of 0.', 'object-sync-for-salesforce' ) );
-
-								if ( 1 === count( $mapping_object_debug ) ) {
-									// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the Salesforce object it was trying to map
-									$body = sprintf( esc_html__( 'There is an object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of 0 and the Salesforce object with ID of %3$s', 'object-sync-for-salesforce' ),
-										absint( $mapping_object_debug['id'] ),
-										esc_attr( $salesforce_mapping['wordpress_object'] ),
-										esc_attr( $mapping_object_debug['salesforce_id'] )
-									);
-								} else {
-									$body = sprintf( esc_html__( 'There are multiple object maps with WordPress ID of 0. Their IDs are: ', 'object-sync-for-salesforce' ) . '<ul>' );
-									foreach ( $mapping_object_debug as $mapping_object ) {
-										// translators: placeholders are: 1) the mapping object row ID, 2) the ID of the Salesforce object, 3) the WordPress object type
-										$body .= sprintf( '<li>' . esc_html__( 'Mapping object id: %1$s. Salesforce Id: %2$s. WordPress object type: %3$s', 'object-sync-for-salesforce' ) . '</li>',
-											absint( $mapping_object['id'] ),
-											esc_attr( $mapping_object['salesforce_id'] ),
-											esc_attr( $salesforce_mapping['wordpress_object'] )
-										);
-									}
-									$body .= sprintf( '</ul>' );
-								}
-
-								if ( isset( $this->logging ) ) {
-									$logging = $this->logging;
-								} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-									$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-								}
-								$parent = 0;
-
-								$result = array(
-									'title'   => $title,
-									'message' => $body,
-									'trigger' => $sf_sync_trigger,
-									'parent'  => $parent,
-									'status'  => $status,
-								);
-
-								$logging->setup( $result );
-
-								$results[] = $result;
-							} // End if().
-						} // End if().
-
-						// there is already a mapping object. don't change the WordPress data to match this new Salesforce record, but log it
-						if ( isset( $mapping_object['id'] ) ) {
-							// set the transient so that salesforce_push doesn't start doing stuff, then return out of here
-							set_transient( 'salesforce_pulling_' . $mapping_object['id'], 1, $seconds );
-							set_transient( 'salesforce_pulling_object_id', $mapping_object['id'] );
-							// create log entry to indicate that nothing happened
-							$status = 'notice';
-							// translators: placeholders are: 1) mapping object row id, 2) WordPress object tyoe, 3) individual WordPress item ID, 4) individual Salesforce item ID
-							$title = sprintf( esc_html__( 'Notice: Because object map %1$s already exists, WordPress %2$s %3$s was not mapped to Salesforce Id %4$s', 'object-sync-for-salesforce' ),
-								absint( $mapping_object['id'] ),
-								esc_attr( $salesforce_mapping['wordpress_object'] ),
-								absint( $wordpress_id ),
-								esc_attr( $object['Id'] )
-							);
-
-							// translators: placeholders are 1) WordPress object type, 2) field name for the WordPress id, 3) the WordPress id value, 4) the Salesforce object type, 5) the Salesforce object Id that was modified, 6) the mapping object row id
-							$body = sprintf( esc_html__( 'The WordPress %1$s with %2$s of %3$s is already mapped to the Salesforce %4$s with Id of %5$s in the mapping object with id of %6$s. The Salesforce %4$s with Id of %5$s was created or modified in Salesforce, and would otherwise have been mapped to this WordPress record. No WordPress data has been changed to prevent changing data unintentionally.', 'object-sync-for-salesforce' ),
-								esc_attr( $salesforce_mapping['wordpress_object'] ),
-								esc_attr( $structure['id_field'] ),
-								absint( $wordpress_id ),
-								esc_attr( $salesforce_mapping['salesforce_object'] ),
-								esc_attr( $object['Id'] ),
-								absint( $mapping_object['id'] )
-							);
-
-							if ( isset( $this->logging ) ) {
-								$logging = $this->logging;
-							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-							}
-							// if we know the WordPress object id we can put it in there
-							if ( null !== $wordpress_id ) {
-								$parent = $wordpress_id;
-							} else {
-								$parent = 0;
-							}
-
-							$result = array(
-								'title'   => $title,
-								'message' => $body,
-								'trigger' => $sf_sync_trigger,
-								'parent'  => $parent,
-								'status'  => $status,
-							);
-
-							$logging->setup( $result );
-
-							$results[] = $result;
-
-							// exit out of here without saving any data in WordPress
-							continue;
-						} // End if().
-
-						// right here we should set the pulling transient
-						// this means we have to create the mapping object here as well, and update it with the correct IDs after successful response
-						// create the mapping object between the rows
-						$mapping_object_id = $this->create_object_map( $object, $this->mappings->generate_temporary_id( 'pull' ), $mapping );
-						set_transient( 'salesforce_pulling_' . $mapping_object_id, 1, $seconds );
-						set_transient( 'salesforce_pulling_object_id', $mapping_object_id );
-						$mapping_object = $this->mappings->get_object_maps(
-							array(
-								'id' => $mapping_object_id,
-							)
-						);
-
-						// now we can upsert the object in wp if we've gotten to this point
-						// this command will either create or update the object
-						$result = $this->wordpress->object_upsert( $salesforce_mapping['wordpress_object'], $upsert_key, $upsert_value, $upsert_methods, $params, $salesforce_mapping['pull_to_drafts'] );
-
-					} else {
-						// No key or prematch field exists on this field map object, create a new object in WordPress.
-						$op                = 'Create';
-						$mapping_object_id = $this->create_object_map( $object, $this->mappings->generate_temporary_id( 'pull' ), $mapping );
-						set_transient( 'salesforce_pulling_' . $mapping_object_id, 1, $seconds );
-						set_transient( 'salesforce_pulling_object_id', $mapping_object_id );
-						$mapping_object = $this->mappings->get_object_maps(
-							array(
-								'id' => $mapping_object_id,
-							)
-						);
-
-						$result = $this->wordpress->object_create( $salesforce_mapping['wordpress_object'], $params );
-					} // End if().
-				} catch ( WordpressException $e ) {
-					// create log entry for failed create or upsert
-					$status = 'error';
-
-					// translators: placeholders are: 1) what operation is happening, and 2) the name of the WordPress object
-					$title = sprintf( esc_html__( 'Error: %1$s WordPress %2$s', 'object-sync-for-salesforce' ),
-						esc_attr( $op ),
-						esc_attr( $salesforce_mapping['wordpress_object'] )
+				// there is already a mapping object. don't change the WordPress data to match this new Salesforce record, but log it
+				if ( isset( $mapping_object['id'] ) ) {
+					// set the transient so that salesforce_push doesn't start doing stuff, then return out of here
+					set_transient( 'salesforce_pulling_' . $mapping_object['salesforce_id'], 1, $seconds );
+					set_transient( 'salesforce_pulling_object_id', $mapping_object['salesforce_id'] );
+					// create log entry to indicate that nothing happened
+					$status = 'notice';
+					// translators: placeholders are: 1) mapping object row id, 2) WordPress object tyoe, 3) individual WordPress item ID, 4) individual Salesforce item ID
+					$title = sprintf( esc_html__( 'Notice: Because object map %1$s already exists, WordPress %2$s %3$s was not mapped to Salesforce Id %4$s', 'object-sync-for-salesforce' ),
+						absint( $mapping_object['id'] ),
+						esc_attr( $salesforce_mapping['wordpress_object'] ),
+						absint( $wordpress_id ),
+						esc_attr( $object['Id'] )
 					);
 
-					if ( null !== $salesforce_id ) {
-						$title .= ' ' . $salesforce_id;
-					}
-
-					// translators: placeholders are: 1) the name of the Salesforce object, and 2) Id of the Salesforce object
-					$title .= sprintf( esc_html__( ' (Salesforce %1$s with Id of %2$s)', 'object-sync-for-salesforce' ),
-						$salesforce_mapping['salesforce_object'],
-						$object['Id']
+					// translators: placeholders are 1) WordPress object type, 2) field name for the WordPress id, 3) the WordPress id value, 4) the Salesforce object type, 5) the Salesforce object Id that was modified, 6) the mapping object row id
+					$body = sprintf( esc_html__( 'The WordPress %1$s with %2$s of %3$s is already mapped to the Salesforce %4$s with Id of %5$s in the mapping object with id of %6$s. The Salesforce %4$s with Id of %5$s was created or modified in Salesforce, and would otherwise have been mapped to this WordPress record. No WordPress data has been changed to prevent changing data unintentionally.', 'object-sync-for-salesforce' ),
+						esc_attr( $salesforce_mapping['wordpress_object'] ),
+						esc_attr( $structure['id_field'] ),
+						absint( $wordpress_id ),
+						esc_attr( $salesforce_mapping['salesforce_object'] ),
+						esc_attr( $object['Id'] ),
+						absint( $mapping_object['id'] )
 					);
 
 					if ( isset( $this->logging ) ) {
@@ -1763,7 +1650,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					$result = array(
 						'title'   => $title,
-						'message' => $e->getMessage(),
+						'message' => $body,
 						'trigger' => $sf_sync_trigger,
 						'parent'  => $parent,
 						'status'  => $status,
@@ -1773,148 +1660,377 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					$results[] = $result;
 
-					if ( false === $hold_exceptions ) {
-						throw $e;
-					}
-					if ( empty( $exception ) ) {
-						$exception = $e;
-					} else {
-						$my_class  = get_class( $e );
-						$exception = new $my_class( $e->getMessage(), $e->getCode(), $exception );
-					}
-
-					// hook for pull fail
-					do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
-
-					continue;
-				} // End try().
-
-				// set $wordpress_data to the query result
-				$wordpress_data = $result['data'];
-				if ( isset( $wordpress_data[ "$object_id" ] ) ) {
-					$wordpress_id = $wordpress_data[ "$object_id" ];
-				} else {
-					$wordpress_id = 0;
-				}
-
-				// WordPress crud call was successful
-				// this means the object has already been created/updated in WordPress
-				// this is not redundant because this is where it creates the object mapping rows in WordPress if the object does not already have one (we are still inside $is_new === TRUE here)
-
-				if ( empty( $result['errors'] ) ) {
-					$status = 'success';
-
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-					$title = sprintf( esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s Id of %6$s)', 'object-sync-for-salesforce' ),
-						esc_attr( $op ),
-						esc_attr( $salesforce_mapping['wordpress_object'] ),
-						esc_attr( $object_id ),
-						esc_attr( $wordpress_id ),
-						esc_attr( $salesforce_mapping['salesforce_object'] ),
-						esc_attr( $object['Id'] )
-					);
-
-					$result = array(
-						'title'   => $title,
-						'message' => '',
-						'trigger' => $sf_sync_trigger,
-						'parent'  => $wordpress_id,
-						'status'  => $status,
-					);
-
-					$logging->setup( $result );
-
-					$results[] = $result;
-
-					// update that mapping object
-					$mapping_object['wordpress_id'] = $wordpress_id;
-					$mapping_object                 = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
-
-					// hook for pull success
-					do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
-				} else {
-
-					// create log entry for failed create or upsert
-					// this is part of the drupal module but i am failing to understand when it would ever fire, since the catch should catch the errors
-					// if we see this in the log entries, we can understand what it does, but probably not until then
-					$status = 'error';
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
-					if ( is_object( $wordpress_id ) ) {
-						// print this array because if this happens, something weird has happened and we want to log whatever we have
-						$wordpress_id = print_r( $wordpress_id, true );
-					}
-
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object type, 3) the Salesforce object Id value
-					$title = sprintf( esc_html__( 'Error syncing: %1$s to WordPress (Salesforce %2$s Id %3$s)', 'object-sync-for-salesforce' ),
-						esc_attr( $op ),
-						esc_attr( $salesforce_mapping['salesforce_object'] ),
-						esc_attr( $object['Id'] )
-					);
-
-					// translators: placeholders are: 1) the name of the WordPress object type, 2) the WordPress id field name, 3) the WordPress id field value, 4) the array of errors
-					$body = sprintf( '<p>' . esc_html__( 'Object: %1$s with %2$s of %3$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: ', 'object-sync-for-salesforce' ) . '%4$s',
-						esc_attr( $salesforce_mapping['wordpress_object'] ),
-						esc_attr( $object_id ),
-						esc_attr( $wordpress_id ),
-						print_r( $result['errors'], true ) // if we get this error, we need to know whatever we have
-					);
-
-					$result = array(
-						'title'   => $title,
-						'message' => $body,
-						'trigger' => $sf_sync_trigger,
-						'parent'  => $wordpress_id,
-						'status'  => $status,
-					);
-
-					$logging->setup( $result );
-
-					$results[] = $result;
-
-					// hook for pull fail
-					do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
-
-					continue;
 				} // End if().
-			} elseif ( false === $is_new ) {
 
 				// right here we should set the pulling transient
-				set_transient( 'salesforce_pulling_' . $mapping_object['id'], 1, $seconds );
-				set_transient( 'salesforce_pulling_object_id', $mapping_object['id'] );
+				// this means we have to create the mapping object here as well, and update it with the correct IDs after successful response
+				// create the mapping object between the rows
+				$mapping_object_id = $this->create_object_map( $object, $this->mappings->generate_temporary_id( 'pull' ), $salesforce_mapping );
+				set_transient( 'salesforce_pulling_' . $object['Id'], 1, $seconds );
+				set_transient( 'salesforce_pulling_object_id', $object['Id'] );
+				$mapping_object = $this->mappings->get_object_maps(
+					array(
+						'id' => $mapping_object_id,
+					)
+				);
 
-				// there is an existing object link
-				// if the last sync is greater than the last time this object was updated by Salesforce, skip it
-				// this keeps us from doing redundant syncs
-				// because SF stores all DateTimes in UTC.
-				$mapping_object['object_updated'] = current_time( 'mysql' );
+				// now we can upsert the object in wp if we've gotten to this point
+				// this command will either create or update the object
+				$result = $this->wordpress->object_upsert( $salesforce_mapping['wordpress_object'], $upsert_key, $upsert_value, $upsert_methods, $params, $salesforce_mapping['pull_to_drafts'] );
 
-				$pull_trigger_field = $salesforce_mapping['pull_trigger_field'];
-				$pull_trigger_value = $object[ $pull_trigger_field ];
+			} else {
+				// No key or prematch field exists on this field map object, create a new object in WordPress.
+				$op                = 'Create';
+				$mapping_object_id = $this->create_object_map( $object, $this->mappings->generate_temporary_id( 'pull' ), $salesforce_mapping );
+				set_transient( 'salesforce_pulling_' . $mapping_object_id, 1, $seconds );
+				set_transient( 'salesforce_pulling_object_id', $mapping_object_id );
+				$mapping_object = $this->mappings->get_object_maps(
+					array(
+						'id' => $mapping_object_id,
+					)
+				);
 
+				$result = $this->wordpress->object_create( $salesforce_mapping['wordpress_object'], $params );
+			} // End if().
+		} catch ( WordpressException $e ) {
+			// create log entry for failed create or upsert
+			$status = 'error';
+
+			// translators: placeholders are: 1) what operation is happening, and 2) the name of the WordPress object
+			$title = sprintf( esc_html__( 'Error: %1$s WordPress %2$s', 'object-sync-for-salesforce' ),
+				esc_attr( $op ),
+				esc_attr( $salesforce_mapping['wordpress_object'] )
+			);
+
+			if ( null !== $salesforce_id ) {
+				$title .= ' ' . $salesforce_id;
+			}
+
+			// translators: placeholders are: 1) the name of the Salesforce object, and 2) Id of the Salesforce object
+			$title .= sprintf( esc_html__( ' (Salesforce %1$s with Id of %2$s)', 'object-sync-for-salesforce' ),
+				$salesforce_mapping['salesforce_object'],
+				$object['Id']
+			);
+
+			if ( isset( $this->logging ) ) {
+				$logging = $this->logging;
+			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+			}
+
+			// if we know the WordPress object id we can put it in there
+			if ( null !== $wordpress_id ) {
+				$parent = $wordpress_id;
+			} else {
+				$parent = 0;
+			}
+
+			$result = array(
+				'title'   => $title,
+				'message' => $e->getMessage(),
+				'trigger' => $sf_sync_trigger,
+				'parent'  => $parent,
+				'status'  => $status,
+			);
+
+			$logging->setup( $result );
+
+			$results[] = $result;
+
+			if ( false === $hold_exceptions ) {
+				throw $e;
+			}
+			if ( empty( $exception ) ) {
+				$exception = $e;
+			} else {
+				$my_class  = get_class( $e );
+				$exception = new $my_class( $e->getMessage(), $e->getCode(), $exception );
+			}
+
+			// hook for pull fail
+			do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
+
+		} // End try().
+
+		// set $wordpress_data to the query result
+		$wordpress_data = $result['data'];
+		if ( isset( $wordpress_data[ "$wordpress_id_field_name" ] ) ) {
+			$wordpress_id = $wordpress_data[ "$wordpress_id_field_name" ];
+		} else {
+			$wordpress_id = 0;
+		}
+
+		// WordPress crud call was successful
+		// this means the object has already been created/updated in WordPress
+		// this is not redundant because this is where it creates the object mapping rows in WordPress if the object does not already have one (we are still inside $is_new === TRUE here)
+
+		if ( empty( $result['errors'] ) ) {
+			$status = 'success';
+
+			if ( isset( $this->logging ) ) {
+				$logging = $this->logging;
+			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+			}
+
+			// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
+			$title = sprintf( esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s Id of %6$s)', 'object-sync-for-salesforce' ),
+				esc_attr( $op ),
+				esc_attr( $salesforce_mapping['wordpress_object'] ),
+				esc_attr( $wordpress_id_field_name ),
+				esc_attr( $wordpress_id ),
+				esc_attr( $salesforce_mapping['salesforce_object'] ),
+				esc_attr( $object['Id'] )
+			);
+
+			$result = array(
+				'title'   => $title,
+				'message' => '',
+				'trigger' => $sf_sync_trigger,
+				'parent'  => $wordpress_id,
+				'status'  => $status,
+			);
+
+			$logging->setup( $result );
+
+			$results[] = $result;
+
+			// update that mapping object
+			$mapping_object['wordpress_id'] = $wordpress_id;
+			$mapping_object                 = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+
+			// hook for pull success
+			do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
+		} else {
+
+			// create log entry for failed create or upsert
+			// this is part of the drupal module but i am failing to understand when it would ever fire, since the catch should catch the errors
+			// if we see this in the log entries, we can understand what it does, but probably not until then
+			$status = 'error';
+			if ( isset( $this->logging ) ) {
+				$logging = $this->logging;
+			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+			}
+
+			if ( is_object( $wordpress_id ) ) {
+				// print this array because if this happens, something weird has happened and we want to log whatever we have
+				$wordpress_id = print_r( $wordpress_id, true );
+			}
+
+			// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object type, 3) the Salesforce object Id value
+			$title = sprintf( esc_html__( 'Error syncing: %1$s to WordPress (Salesforce %2$s Id %3$s)', 'object-sync-for-salesforce' ),
+				esc_attr( $op ),
+				esc_attr( $salesforce_mapping['salesforce_object'] ),
+				esc_attr( $object['Id'] )
+			);
+
+			// translators: placeholders are: 1) the name of the WordPress object type, 2) the WordPress id field name, 3) the WordPress id field value, 4) the array of errors
+			$body = sprintf( '<p>' . esc_html__( 'Object: %1$s with %2$s of %3$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: ', 'object-sync-for-salesforce' ) . '%4$s',
+				esc_attr( $salesforce_mapping['wordpress_object'] ),
+				esc_attr( $wordpress_id_field_name ),
+				esc_attr( $wordpress_id ),
+				print_r( $result['errors'], true ) // if we get this error, we need to know whatever we have
+			);
+
+			$result = array(
+				'title'   => $title,
+				'message' => $body,
+				'trigger' => $sf_sync_trigger,
+				'parent'  => $wordpress_id,
+				'status'  => $status,
+			);
+
+			$logging->setup( $result );
+
+			$results[] = $result;
+
+			// hook for pull fail
+			do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
+
+		} // End if().
+		return $results;
+	}
+
+	/**
+	* Update records in WordPress from a Salesforce pull
+	*
+	* @param string $sf_sync_trigger
+	*   The current operation's trigger
+	* @param array $synced_object
+	*   Combined data for fieldmap, mapping object, and Salesforce object data
+	* @param array $params
+	*   Array of mapped key value pairs between WordPress and Salesforce fields.
+	* @param string $wordpress_id_field_name
+	*   The name of the ID field for this particular WordPress object type
+	* @param int $seconds
+	*   Timeout for the transient value to determine the direction for a sync.
+	* @return array $results
+	*   Currently this contains an array of log entries for each attempt.
+	*
+	*/
+	private function update_called_from_salesforce( $sf_sync_trigger, $synced_object, $params, $wordpress_id_field_name, $seconds ) {
+
+		$salesforce_mapping = $synced_object['mapping'];
+		$mapping_object     = $synced_object['mapping_object'];
+		$object             = $synced_object['salesforce_object'];
+
+		// methods to run the wp update operations
+		$results = array();
+		$op      = '';
+
+		// if the last sync is greater than the last time this object was updated by Salesforce, skip it
+		// this keeps us from doing redundant syncs
+		// because SF stores all DateTimes in UTC.
+		$mapping_object['object_updated'] = current_time( 'mysql' );
+
+		$pull_trigger_field = $salesforce_mapping['pull_trigger_field'];
+		$pull_trigger_value = $object[ $pull_trigger_field ];
+
+		// hook to allow other plugins to do something right before WordPress data is saved
+		// ex: run outside methods on an object if it exists, or do something in preparation for it if it doesn't
+		//do_action( $this->option_prefix . 'pre_pull', $mapping_object['wordpress_id'], $salesforce_mapping, $object, $wordpress_id_field_name, $params );
+
+		try {
+
+			$op     = 'Update';
+			$result = $this->wordpress->object_update( $salesforce_mapping['wordpress_object'], $mapping_object['wordpress_id'], $params );
+
+			$mapping_object['last_sync_status']  = $this->mappings->status_success;
+			$mapping_object['last_sync_message'] = esc_html__( 'Mapping object updated via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__;
+
+			$status = 'success';
+			if ( isset( $this->logging ) ) {
+				$logging = $this->logging;
+			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+			}
+
+			// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
+			$title = sprintf( esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s Id of %6$s)', 'object-sync-for-salesforce' ),
+				esc_attr( $op ),
+				esc_attr( $salesforce_mapping['wordpress_object'] ),
+				esc_attr( $wordpress_id_field_name ),
+				esc_attr( $mapping_object['wordpress_id'] ),
+				esc_attr( $salesforce_mapping['salesforce_object'] ),
+				esc_attr( $object['Id'] )
+			);
+
+			$result = array(
+				'title'   => $title,
+				'message' => '',
+				'trigger' => $sf_sync_trigger,
+				'parent'  => $mapping_object['wordpress_id'],
+				'status'  => $status,
+			);
+
+			$logging->setup( $result );
+
+			$results[] = $result;
+
+			// hook for pull success
+			do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
+
+		} catch ( WordpressException $e ) {
+			// create log entry for failed update
+			$status = 'error';
+			if ( isset( $this->logging ) ) {
+				$logging = $this->logging;
+			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+			}
+
+			// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
+			$title .= sprintf( esc_html__( 'Error: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s with Id of %6$s)', 'object-sync-for-salesforce' ),
+				esc_attr( $op ),
+				esc_attr( $salesforce_mapping['wordpress_object'] ),
+				esc_attr( $wordpress_id_field_name ),
+				esc_attr( $mapping_object['wordpress_id'] ),
+				esc_attr( $salesforce_mapping['salesforce_object'] ),
+				esc_attr( $object['Id'] )
+			);
+
+			$result = array(
+				'title'   => $title,
+				'message' => $e->getMessage(),
+				'trigger' => $sf_sync_trigger,
+				'parent'  => $mapping_object['wordpress_id'],
+				'status'  => $status,
+			);
+
+			$logging->setup( $result );
+
+			$results[] = $result;
+
+			$mapping_object['last_sync_status']  = $this->mappings->status_error;
+			$mapping_object['last_sync_message'] = $e->getMessage();
+
+			if ( false === $hold_exceptions ) {
+				throw $e;
+			}
+			if ( empty( $exception ) ) {
+				$exception = $e;
+			} else {
+				$my_class  = get_class( $e );
+				$exception = new $my_class( $e->getMessage(), $e->getCode(), $exception );
+			}
+
+			// hook for pull fail
+			do_action( $this->option_prefix . 'pull_fail', $op, $result, $synced_object );
+
+		} // End try().
+
+		// need to move these into the success check
+
+		// maybe can check to see if we actually updated anything in WordPress
+		// tell the mapping object - whether it is new or already existed - how we just used it
+		$mapping_object['last_sync_action'] = 'pull';
+		$mapping_object['last_sync']        = current_time( 'mysql' );
+
+		// update that mapping object. the Salesforce data version will be set here as well because we set it earlier
+		$update_object_map = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+
+		return $results;
+
+	}
+
+	/**
+	* Delete records in WordPress from a Salesforce pull
+	*
+	* @param string $sf_sync_trigger
+	*   The current operation's trigger
+	* @param array $synced_object
+	*   Combined data for fieldmap, mapping object, and Salesforce object data
+	* @param string $wordpress_id_field_name
+	*   The name of the ID field for this particular WordPress object type
+	* @param int $seconds
+	*   Timeout for the transient value to determine the direction for a sync.
+	* @return array $results
+	*   Currently this contains an array of log entries for each attempt.
+	*
+	*/
+	private function delete_called_from_salesforce( $sf_sync_trigger, $synced_object, $wordpress_id_field_name, $seconds ) {
+
+		$salesforce_mapping = $synced_object['mapping'];
+		$mapping_object     = $synced_object['mapping_object'];
+
+		// methods to run the wp delete operations
+		$results = array();
+		$op      = '';
+
+		// deleting mapped objects
+		if ( $sf_sync_trigger == $this->mappings->sync_sf_delete ) { // trigger is a bit operator
+			if ( isset( $mapping_object['id'] ) ) {
+
+				set_transient( 'salesforce_pulling_' . $mapping_object['salesforce_id'], 1, $seconds );
+				set_transient( 'salesforce_pulling_object_id', $mapping_object['salesforce_id'] );
+
+				$op = 'Delete';
 				try {
-
-					// hook to allow other plugins to do something right before WordPress data is saved
-					// ex: run outside methods on an object if it exists, or do something in preparation for it if it doesn't
-					do_action( $this->option_prefix . 'pre_pull', $mapping_object['wordpress_id'], $mapping, $object, $object_id, $params );
-
-					$op     = 'Update';
-					$result = $this->wordpress->object_update( $salesforce_mapping['wordpress_object'], $mapping_object['wordpress_id'], $params );
-
-					$mapping_object['last_sync_status']  = $this->mappings->status_success;
-					$mapping_object['last_sync_message'] = esc_html__( 'Mapping object updated via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__;
-
-					$status = 'success';
+					$result = $this->wordpress->object_delete( $salesforce_mapping['wordpress_object'], $mapping_object['wordpress_id'] );
+				} catch ( WordpressException $e ) {
+					$status = 'error';
+					// create log entry for failed delete
 					if ( isset( $this->logging ) ) {
 						$logging = $this->logging;
 					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
@@ -1922,47 +2038,13 @@ class Object_Sync_Sf_Salesforce_Pull {
 					}
 
 					// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-					$title = sprintf( esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s Id of %6$s)', 'object-sync-for-salesforce' ),
+					$title = sprintf( esc_html__( 'Error: %1$s WordPress %2$s with %3$s of %4$s (%5$s %6$s)', 'object-sync-for-salesforce' ),
 						esc_attr( $op ),
 						esc_attr( $salesforce_mapping['wordpress_object'] ),
-						esc_attr( $object_id ),
+						esc_attr( $wordpress_id_field_name ),
 						esc_attr( $mapping_object['wordpress_id'] ),
 						esc_attr( $salesforce_mapping['salesforce_object'] ),
-						esc_attr( $object['Id'] )
-					);
-
-					$result = array(
-						'title'   => $title,
-						'message' => '',
-						'trigger' => $sf_sync_trigger,
-						'parent'  => $mapping_object['wordpress_id'],
-						'status'  => $status,
-					);
-
-					$logging->setup( $result );
-
-					$results[] = $result;
-
-					// hook for pull success
-					do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
-
-				} catch ( WordpressException $e ) {
-					// create log entry for failed update
-					$status = 'error';
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-					$title .= sprintf( esc_html__( 'Error: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s with Id of %6$s)', 'object-sync-for-salesforce' ),
-						esc_attr( $op ),
-						esc_attr( $salesforce_mapping['wordpress_object'] ),
-						esc_attr( $object_id ),
-						esc_attr( $mapping_object['wordpress_id'] ),
-						esc_attr( $salesforce_mapping['salesforce_object'] ),
-						esc_attr( $object['Id'] )
+						esc_attr( $mapping_object['salesforce_id'] )
 					);
 
 					$result = array(
@@ -1977,9 +2059,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					$results[] = $result;
 
-					$mapping_object['last_sync_status']  = $this->mappings->status_error;
-					$mapping_object['last_sync_message'] = $e->getMessage();
-
 					if ( false === $hold_exceptions ) {
 						throw $e;
 					}
@@ -1995,33 +2074,47 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 				} // End try().
 
-				// need to move these into the success check
+				if ( ! isset( $e ) ) {
+					// create log entry for successful delete if the result had no errors
+					$status = 'success';
+					if ( isset( $this->logging ) ) {
+						$logging = $this->logging;
+					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+					}
 
-				// maybe can check to see if we actually updated anything in WordPress
-				// tell the mapping object - whether it is new or already existed - how we just used it
-				$mapping_object['last_sync_action'] = 'pull';
-				$mapping_object['last_sync']        = current_time( 'mysql' );
+					// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
+					$title = sprintf( esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (%5$s %6$s)', 'object-sync-for-salesforce' ),
+						esc_attr( $op ),
+						esc_attr( $salesforce_mapping['wordpress_object'] ),
+						esc_attr( $wordpress_id_field_name ),
+						esc_attr( $mapping_object['wordpress_id'] ),
+						esc_attr( $salesforce_mapping['salesforce_object'] ),
+						esc_attr( $mapping_object['salesforce_id'] )
+					);
 
-				// update that mapping object. the Salesforce data version will be set here as well because we set it earlier
-				$result = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
-				// end of the if statement for is_new & update or create trigger
-				// this keeps stuff from running too many times, and also keeps it from using the wrong methods. we don't need a generic } else { here at this time.
+					$result = array(
+						'title'   => $title,
+						'message' => '',
+						'trigger' => $sf_sync_trigger,
+						'parent'  => $mapping_object['wordpress_id'],
+						'status'  => $status,
+					);
+
+					$logging->setup( $result );
+
+					$results[] = $result;
+
+					// hook for pull success
+					do_action( $this->option_prefix . 'pull_success', $op, $result, $synced_object );
+				} // End if() successful
+
+				// delete the map row from WordPress after the WordPress row has been deleted
+				// we delete the map row even if the WordPress delete failed, because the Salesforce object is gone
+				$this->mappings->delete_object_map( $mapping_object['id'] );
+				// there is no map row if we end this if statement
 			} // End if().
-		} // End foreach().
-
-		// delete transients that we've already processed
-		foreach ( $transients_to_delete as $mapping_object_id_transient ) {
-			delete_transient( 'salesforce_pushing_' . $mapping_object_id_transient );
-		}
-
-		$pushing_id = get_transient( 'salesforce_pushing_object_id' );
-		if ( in_array( $pushing_id, $transients_to_delete, true ) ) {
-			delete_transient( 'salesforce_pushing_object_id' );
-		}
-
-		if ( ! empty( $exception ) ) {
-			throw $exception;
-		}
+		} // End if().
 
 		return $results;
 
@@ -2112,14 +2205,14 @@ class Object_Sync_Sf_Salesforce_Pull {
 	*   Whether all this stuff allows the $result to be pulled into WordPress
 	*
 	*/
-	private function is_pull_allowed( $object_type, $object, $sf_sync_trigger, $mapping, $map_sync_triggers ) {
+	private function is_pull_allowed( $object_type, $object, $sf_sync_trigger, $salesforce_mapping, $map_sync_triggers ) {
 
 		// default is pull is allowed
 		$pull_allowed = true;
 
 		// if the current fieldmap does not allow create, we need to check if there is an object map for the Salesforce object Id. if not, set pull_allowed to false.
 		if ( ! in_array( $this->mappings->sync_sf_create, $map_sync_triggers ) ) {
-			$object_map = $this->mappings->load_by_salesforce( $object['Id'] );
+			$object_map = $this->mappings->load_all_by_salesforce( $object['Id'] );
 			if ( empty( $object_map ) ) {
 				$pull_allowed = false;
 			}
@@ -2127,13 +2220,13 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		// Hook to allow other plugins to prevent a pull per-mapping.
 		// Putting the pull_allowed hook here will keep the queue from storing data when it is not supposed to store it
-		$pull_allowed = apply_filters( $this->option_prefix . 'pull_object_allowed', $pull_allowed, $object_type, $object, $sf_sync_trigger, $mapping );
+		$pull_allowed = apply_filters( $this->option_prefix . 'pull_object_allowed', $pull_allowed, $object_type, $object, $sf_sync_trigger, $salesforce_mapping );
 
 		// example to keep from pulling the Contact with id of abcdef
 		/*
 		add_filter( 'object_sync_for_salesforce_pull_object_allowed', 'check_user', 10, 5 );
 		// can always reduce this number if all the arguments are not necessary
-		function check_user( $pull_allowed, $object_type, $object, $sf_sync_trigger, $mapping ) {
+		function check_user( $pull_allowed, $object_type, $object, $sf_sync_trigger, $salesforce_mapping ) {
 			if ( $object_type === 'Contact' && $object['Id'] === 'abcdef' ) {
 				$pull_allowed = false;
 			}

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -794,9 +794,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$wsdl = get_option( 'object_sync_for_salesforce_soap_wsdl_path', plugin_dir_path( __FILE__ ) . '../vendor/developerforce/force.com-toolkit-for-php/soapclient/partner.wsdl.xml' );
 			$soap = new Object_Sync_Sf_Salesforce_Soap_Partner( $sfapi, $wsdl );
 		}
-
-		$frequencies = $this->queue->get_frequencies();
-		$seconds     = reset( $frequencies )['frequency'] + 60;
+		$seconds = 60;
 
 		$merged_records = array();
 
@@ -860,10 +858,10 @@ class Object_Sync_Sf_Salesforce_Pull {
 						$this->respond_to_salesforce_merge( $type, $record );
 					} // End foreach on merged
 				} // End if on soap
+				if ( ! empty( $merged_records ) ) {
+					set_transient( 'salesforce_merged_' . $type, $merged_records, $seconds );
+				}
 			} // End foreach on mappings
-			if ( ! empty( $merged_records ) ) {
-				set_transient( 'salesforce_merged_' . $type, $merged_records, $seconds );
-			}
 		} // end foreach on types
 
 	}

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -787,9 +787,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 	*/
 	private function get_merged_records() {
 
-		$sfapi = $this->salesforce['sfapi'];
+		$sfapi    = $this->salesforce['sfapi'];
 		$use_soap = filter_var( get_option( 'object_sync_for_salesforce_use_soap', false ), FILTER_VALIDATE_BOOLEAN );
-		$use_soap = true;
 		if ( true === $use_soap ) {
 			$wsdl = get_option( 'object_sync_for_salesforce_soap_wsdl_path', plugin_dir_path( __FILE__ ) . '../vendor/developerforce/force.com-toolkit-for-php/soapclient/partner.wsdl.xml' );
 			$soap = new Object_Sync_Sf_Salesforce_Soap_Partner( $sfapi, $wsdl );
@@ -810,7 +809,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			// Iterate over each field mapping to determine our query parameters.
 			foreach ( $mappings as $salesforce_mapping ) {
 				$last_merge_sync = get_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], current_time( 'timestamp', true ) );
-				$now              = current_time( 'timestamp', true );
+				$now             = current_time( 'timestamp', true );
 				update_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], $now );
 
 				// get_deleted() constraint: startDate cannot be more than 30 days ago
@@ -829,7 +828,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$merged = array();
 				// there doesn't appear to be a way to do this in the rest api; for now we'll do soap
 				if ( true === $use_soap ) {
-					$type   = $salesforce_mapping['salesforce_object'];
+					$type = $salesforce_mapping['salesforce_object'];
 					$query  = "SELECT Id, isDeleted, masterRecordId FROM $type WHERE masterRecordId != '' AND SystemModStamp > $last_merge_sync_sf";
 					$merged = $soap->try_soap( 'queryAll', $query );
 					if ( ! empty( $merged->records ) ) {
@@ -849,8 +848,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 							libxml_use_internal_errors( true );
 							$any = simplexml_load_string( '<?xml version="1.0" standalone="yes"?><root>' . $result['any'] . '</root>' );
 							if ( $any ) {
-							    $json   = wp_json_encode( $any );
-								$array  = json_decode( $json, TRUE );
+								$json   = wp_json_encode( $any );
+								$array  = json_decode( $json, true );
 								$record = array_merge( $record, $array );
 							}
 						}
@@ -884,7 +883,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$wordpress_type                  = $mapping_object['wordpress_object'];
 				$wordpress_id                    = $mapping_object['wordpress_id'];
 				$mapping_object['salesforce_id'] = $new_sf_id;
-				$mapping_object = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+				$mapping_object                  = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
 
 				$status = 'success';
 

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -70,6 +70,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 		$this->min_soql_batch_size = 200; // batches cannot be smaller than 200 records
 		$this->max_soql_size       = 2000;
 
+		$this->mergeable_record_types = array( 'Lead', 'Contact', 'Account' );
+
 		// Create action hooks for WordPress objects. We run this after plugins are loaded in case something depends on another plugin.
 		add_action( 'plugins_loaded', array( $this, 'add_actions' ) );
 
@@ -161,6 +163,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		if ( true === $this->salesforce['is_authorized'] && true === $this->check_throttle() ) {
 
 			$this->get_updated_records();
+			$this->get_merged_records();
 			$this->get_deleted_records();
 
 			// Store this request time for the throttle check.
@@ -778,6 +781,146 @@ class Object_Sync_Sf_Salesforce_Pull {
 	}
 
 	/**
+	* Get merged records from Salesforce.
+	* Note that merges can currently only work if the Soap API is enabled.
+	*
+	*/
+	private function get_merged_records() {
+
+		$sfapi = $this->salesforce['sfapi'];
+		$use_soap = filter_var( get_option( 'object_sync_for_salesforce_use_soap', false ), FILTER_VALIDATE_BOOLEAN );
+		$use_soap = true;
+		if ( true === $use_soap ) {
+			$wsdl = get_option( 'object_sync_for_salesforce_soap_wsdl_path', plugin_dir_path( __FILE__ ) . '../vendor/developerforce/force.com-toolkit-for-php/soapclient/partner.wsdl.xml' );
+			$soap = new Object_Sync_Sf_Salesforce_Soap_Partner( $sfapi, $wsdl );
+		}
+
+		$frequencies = $this->queue->get_frequencies();
+		$seconds     = reset( $frequencies )['frequency'] + 60;
+
+		$merged_records = array();
+
+		// Load fieldmaps for mergeable types
+		foreach ( $this->mergeable_record_types as $type ) {
+			$mappings = $this->mappings->get_fieldmaps(
+				null,
+				array(
+					'salesforce_object' => $type,
+				)
+			);
+
+			// Iterate over each field mapping to determine our query parameters.
+			foreach ( $mappings as $salesforce_mapping ) {
+				$last_merge_sync = get_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], current_time( 'timestamp', true ) );
+				$now              = current_time( 'timestamp', true );
+				update_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], $now );
+
+				// get_deleted() constraint: startDate cannot be more than 30 days ago
+				// (using an incompatible date may lead to exceptions).
+				$last_merge_sync = $last_merge_sync > ( current_time( 'timestamp', true ) - 2505600 ) ? $last_merge_sync : ( current_time( 'timestamp', true ) - 2505600 );
+
+				// get_deleted() constraint: startDate must be at least one minute greater
+				// than endDate.
+				$now = $now > ( $last_merge_sync + 60 ) ? $now : $now + 60;
+
+				// need to be using gmdate for Salesforce call
+				$last_merge_sync_sf = gmdate( 'Y-m-d\TH:i:s\Z', $last_merge_sync );
+
+				// we want to add something like this eventually, to the query: AND SystemModstamp > 2006-01-01T23:01:01+01:00
+
+				$merged = array();
+				// there doesn't appear to be a way to do this in the rest api; for now we'll do soap
+				if ( true === $use_soap ) {
+					$type   = $salesforce_mapping['salesforce_object'];
+					$query  = "SELECT Id, isDeleted, masterRecordId FROM $type WHERE masterRecordId != '' AND SystemModStamp > $last_merge_sync_sf";
+					$merged = $soap->try_soap( 'queryAll', $query );
+					if ( ! empty( $merged->records ) ) {
+						$merged = json_decode( wp_json_encode( $merged->records ), true );
+					} else {
+						continue;
+					}
+
+					foreach ( $merged as $result ) {
+						$record = array();
+						if ( is_array( array_unique( $result['Id'] ) ) ) {
+							$record['Id'] = array_unique( $result['Id'] )[0];
+						} else {
+							$record['Id'] = $result['Id'];
+						}
+						if ( isset( $result['any'] ) ) {
+							libxml_use_internal_errors( true );
+							$any = simplexml_load_string( '<?xml version="1.0" standalone="yes"?><root>' . $result['any'] . '</root>' );
+							if ( $any ) {
+							    $json   = wp_json_encode( $any );
+								$array  = json_decode( $json, TRUE );
+								$record = array_merge( $record, $array );
+							}
+						}
+						$merged_records[] = $record;
+						$this->respond_to_salesforce_merge( $type, $record );
+					} // End foreach on merged
+				} // End if on soap
+			} // End foreach on mappings
+			if ( ! empty( $merged_records ) ) {
+				set_transient( 'salesforce_merged_' . $type, $merged_records, $seconds );
+			}
+		} // end foreach on types
+
+	}
+
+	/**
+	* Respond to Salesforce merge events
+	* This means we update the mapping object to contain the new Salesforce Id, and pull its data
+	*
+	* @param string $object_type
+	* @param array $merged_record
+	*
+	*/
+	private function respond_to_salesforce_merge( $object_type, $merged_record ) {
+		$op = 'Merge';
+		if ( isset( $merged_record['Id'] ) && true === filter_var( $merged_record['sf:IsDeleted'], FILTER_VALIDATE_BOOLEAN ) && '' !== $merged_record['sf:MasterRecordId'] ) {
+			$previous_sf_id  = $merged_record['Id'];
+			$new_sf_id       = $merged_record['sf:MasterRecordId'];
+			$mapping_objects = $this->mappings->load_all_by_salesforce( $previous_sf_id );
+			foreach ( $mapping_objects as $mapping_object ) {
+				$wordpress_type                  = $mapping_object['wordpress_object'];
+				$wordpress_id                    = $mapping_object['wordpress_id'];
+				$mapping_object['salesforce_id'] = $new_sf_id;
+				$mapping_object = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+
+				$status = 'success';
+
+				if ( isset( $this->logging ) ) {
+					$logging = $this->logging;
+				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+				}
+
+				// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object type, 3) the previous Salesforce Id value, 4) the new Salesforce Id value, 5) the name of the WordPress object, 6) the WordPress id value
+				$title = sprintf( esc_html__( 'Success: %1$s Salesforce %2$s objects with Ids %3$s and %4$s were merged (%4$s is the remaining ID. It is mapped to WordPress %5$s with %6$s.)', 'object-sync-for-salesforce' ),
+					esc_attr( $op ),
+					esc_attr( $object_type ),
+					esc_attr( $previous_sf_id ),
+					esc_attr( $new_sf_id ),
+					esc_attr( $wordpress_type ),
+					esc_attr( $wordpress_id ),
+				);
+
+				$result = array(
+					'title'   => $title,
+					'message' => '',
+					'trigger' => 0,
+					'parent'  => $wordpress_id,
+					'status'  => $status,
+				);
+
+				$logging->setup( $result );
+
+			}
+		}
+	}
+
+	/**
 	* Get deleted records from salesforce.
 	* Note that deletions can only be queried via REST with an API version >= 29.0.
 	*
@@ -824,6 +967,20 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 				// Salesforce call
 				$deleted = $sfapi->get_deleted( $type, $last_delete_sync_sf, $now_sf );
+				$merged  = get_transient( 'salesforce_merged_' . $type );
+				if ( false !== $merged && isset( $deleted['data']['deletedRecords'] ) ) {
+					foreach ( $merged as $key ) {
+						$deleted['data']['deletedRecords'] = array_filter(
+							$deleted['data']['deletedRecords'],
+							function( $x ) use ( $key ) {
+								if ( ! isset( $x['Id'] ) && isset( $x['id'] ) ) {
+									$x['Id'] = $x['id'];
+								}
+								return $x['Id'] !== $key;
+							}
+						);
+					}
+				}
 
 				if ( empty( $deleted['data']['deletedRecords'] ) ) {
 					continue;

--- a/object-sync-for-salesforce.php
+++ b/object-sync-for-salesforce.php
@@ -86,12 +86,6 @@ class Object_Sync_Salesforce {
 	*/
 	public $salesforce;
 
-	/**
-	* @var object
-	* Load and initialize the Salesforce_Soap class.
-	* this contains the Salesforce SOAP client
-	*/
-	public $salesforce_soap_partner;
 
 	/**
 	* @var object
@@ -207,7 +201,6 @@ class Object_Sync_Salesforce {
 
 		$this->wordpress  = $this->wordpress( $this->wpdb, $this->version, $this->slug, $this->option_prefix, $this->mappings, $this->logging );
 		$this->salesforce = $this->salesforce_get_api();
-		$this->salesforce_soap_partner = $this->salesforce_soap_partner( $this->salesforce['sfapi'] );
 
 		$this->push = $this->push( $this->wpdb, $this->version, $this->login_credentials, $this->slug, $this->option_prefix, $this->wordpress, $this->salesforce, $this->mappings, $this->logging, $this->schedulable_classes, $this->queue );
 
@@ -312,6 +305,7 @@ class Object_Sync_Salesforce {
 	public function salesforce_get_api() {
 		require_once( plugin_dir_path( __FILE__ ) . 'classes/salesforce.php' );
 		require_once( plugin_dir_path( __FILE__ ) . 'classes/salesforce_query.php' ); // this can be used to generate soql queries, but we don't often need it so it gets initialized whenever it's needed
+		require_once( plugin_dir_path( __FILE__ ) . 'classes/salesforce_soap_partner.php' );
 		$consumer_key        = $this->login_credentials['consumer_key'];
 		$consumer_secret     = $this->login_credentials['consumer_secret'];
 		$login_url           = $this->login_credentials['login_url'];
@@ -336,18 +330,6 @@ class Object_Sync_Salesforce {
 			'is_authorized' => $is_authorized,
 			'sfapi'         => $sfapi,
 		);
-	}
-
-	/**
-	* Public helper to load the Salesforce SOAP client
-	* This is public so other plugins can access the same SF instance
-	*
-	* @return
-	*/
-	public function salesforce_soap_partner( $sfapi ) {
-		require_once( plugin_dir_path( __FILE__ ) . 'classes/salesforce_soap_partner.php' );
-		$salesforce_soap_partner = new Object_Sync_Sf_Salesforce_Soap_Partner( $sfapi );
-		return $salesforce_soap_partner;
 	}
 
 	/**


### PR DESCRIPTION
## What does this PR do?

This uses the SOAP api to add support for merging records. Thus it fixes #197.

## How do I test this PR?

- Merge two records in Salesforce where both are mapped to WordPress records.
- They should both be mapped to the same Salesforce record.
- Also delete a record from Salesforce that is not a merge, and it should still work.