### PR TITLE
Delete object maps from user profile

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -2075,11 +2075,13 @@ class Object_Sync_Sf_Admin {
 			);
 			if ( count( $mappings ) > 0 ) {
 				foreach ( $mappings as $mapping ) {
-					if ( isset( $mapping['id'] ) && ! isset( $get_data['edit_salesforce_mapping'] ) ) {
+					if ( isset( $mapping['id'] ) && ! isset( $get_data['edit_salesforce_mapping'] ) && ! isset( $get_data['delete_salesforce_mapping'] ) ) {
 						require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/user-profile-salesforce.php' );
 					} elseif ( ! empty( $fieldmap ) ) { // is the user mapped to something already?
 						if ( isset( $get_data['edit_salesforce_mapping'] ) && true === filter_var( $get_data['edit_salesforce_mapping'], FILTER_VALIDATE_BOOLEAN ) ) {
 							require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/user-profile-salesforce-change.php' );
+						} elseif ( isset( $get_data['delete_salesforce_mapping'] ) && true === filter_var( $get_data['delete_salesforce_mapping'], FILTER_VALIDATE_BOOLEAN ) ) {
+							require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/user-profile-salesforce-delete.php' );
 						} else {
 							require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/user-profile-salesforce-map.php' );
 						}
@@ -2115,6 +2117,11 @@ class Object_Sync_Sf_Admin {
 			} elseif ( isset( $post_data['push_new_user_to_salesforce'] ) ) {
 				// otherwise, create a new record in Salesforce
 				$result = $this->push_to_salesforce( 'user', $user_id );
+			}
+		} elseif ( isset( $post_data['salesforce_delete_mapped_user'] ) && true === filter_var( $post_data['salesforce_delete_mapped_user'], FILTER_VALIDATE_BOOLEAN ) ) {
+			// if a Salesforce ID was entered
+			if ( isset( $post_data['mapping_id'] ) && ! empty( $post_data['mapping_id'] ) ) {
+				$delete = $this->mappings->delete_object_map( $post_data['mapping_id'] );
 			}
 		}
 	}

--- a/templates/admin/user-profile-salesforce-change.php
+++ b/templates/admin/user-profile-salesforce-change.php
@@ -5,7 +5,7 @@
 	<tr>
 		<th><label for="salesforce_id"><?php echo esc_html__( 'Salesforce ID', 'object-sync-for-salesforce' ); ?></label></th>
 		<td>
-			<input type="text" name="salesforce_id" id="salesforce_id" value="<?php if ( isset( $mapping['id'] ) ) { echo esc_html( $mapping['salesforce_id'] ); } ?>" class="regular-text" /><br />
+			<input type="text" name="salesforce_id" id="salesforce_id" value="<?php if ( isset( $mapping['id'] ) ) { echo esc_attr( $mapping['salesforce_id'] ); } ?>" class="regular-text" required /><br />
 			<span class="description"><?php echo esc_html__( 'Enter a Salesforce object ID.', 'object-sync-for-salesforce' ); ?></span>
 		</td>
 	</tr>

--- a/templates/admin/user-profile-salesforce-delete.php
+++ b/templates/admin/user-profile-salesforce-delete.php
@@ -1,0 +1,5 @@
+<input type="hidden" name="salesforce_delete_mapped_user" value="1" />
+<input type="hidden" name="mapping_id" id="mapping_id_ajax" value="<?php echo absint( $mapping['id'] ); ?>" />
+<h2><?php echo esc_html__( 'Salesforce', 'object-sync-for-salesforce' ); ?></h2>
+<p><?php echo esc_html__( 'Confirm that you want to delete the relationship between this WordPress user and the Salesforce object it is connected to. No other data in Salesforce or WordPress will be modified.', 'object-sync-for-salesforce' ); ?></p>
+<p><button type="submit" class="button button-primary delete_mapped_user_button" name="delete_mapped_user"><?php echo esc_html__( 'Confirm deletion', 'object-sync-for-salesforce' ); ?></button></p>

--- a/templates/admin/user-profile-salesforce.php
+++ b/templates/admin/user-profile-salesforce.php
@@ -9,7 +9,10 @@
 		<tr>
 			<th><?php echo esc_html__( 'Salesforce Id', 'object-sync-for-salesforce' ); ?></th>
 			<td><a href="<?php echo esc_url( $this->salesforce['sfapi']->get_instance_url() . '/' . $mapping['salesforce_id'] ); ?>"><?php echo esc_attr( $mapping['salesforce_id'] ); ?></a></td>
-			<td><a href="<?php echo esc_url( get_admin_url( null, 'user-edit.php?user_id=' . $user->ID ) . '&amp;edit_salesforce_mapping=true' ); ?>" class="edit-salesforce-mapping"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a></td>
+			<td>
+				<a href="<?php echo esc_url( get_admin_url( null, 'user-edit.php?user_id=' . $user->ID ) . '&amp;edit_salesforce_mapping=true' ); ?>" class="edit-salesforce-mapping"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a>&nbsp;|&nbsp;
+				<a href="<?php echo esc_url( get_admin_url( null, 'user-edit.php?user_id=' . $user->ID ) . '&amp;delete_salesforce_mapping=true' ); ?>" class="delete-salesforce-mapping"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
+			</td>
 		</tr>
 		<tr>
 			<th><?php echo esc_html__( 'Last Sync Message', 'object-sync-for-salesforce' ); ?></th>


### PR DESCRIPTION
## What does this PR do?
- This fixes #251 by adding a delete option to the user profile Salesforce box. This allows object maps to be deleted in addition to being edited.

## How do I test this PR?
- delete an object map
- edit one too.