### PR TITLE
Support datetime values for The Event Calendar

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -904,9 +904,12 @@ class Object_Sync_Sf_Mapping {
 							if ( 'tribe_events' === $mapping['wordpress_object'] && class_exists( 'Tribe__Events__Main' ) ) {
 								$format = 'Y-m-d H:i:s';
 							}
-							// Note: the Salesforce REST API appears to always return dates as GMT values. We should retrieve them that way, then format them to deal with them in WordPress appropriately.
-							$gmt_date                    = get_date_from_gmt( $object[ $salesforce_field ], 'Y-m-d\TH:i:s\Z' ); // convert from GMT to local date/time based on WordPress time zone setting.
-							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $gmt_date ) );
+							if ( 'datetime' === $salesforce_field_type ) {
+								// Note: the Salesforce REST API appears to always return datetimes as GMT values. We should retrieve them that way, then format them to deal with them in WordPress appropriately.
+								// We should not do any converting unless it's a datetime, because if it's a date, Salesforce stores it as midnight. We don't want to convert that.
+								$object[ $salesforce_field ] = get_date_from_gmt( $object[ $salesforce_field ], 'Y-m-d\TH:i:s\Z' ); // convert from GMT to local date/time based on WordPress time zone setting.
+							}
+							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $object[ $salesforce_field ] ) );
 							break;
 						case ( in_array( $salesforce_field_type, $this->int_types_from_salesforce ) ):
 							$object[ $salesforce_field ] = isset( $object[ $salesforce_field ] ) ? (int) $object[ $salesforce_field ] : 0;

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -901,7 +901,11 @@ class Object_Sync_Sf_Mapping {
 							if ( isset( $fieldmap['wordpress_field']['type'] ) && 'datetime' === $fieldmap['wordpress_field']['type'] ) {
 								$format = 'Y-m-d H:i:s';
 							}
-							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $object[ $salesforce_field ] ) );
+							if ( 'tribe_events' === $mapping['wordpress_object'] && class_exists( 'Tribe__Events__Main' ) ) {
+								$format = 'Y-m-d H:i:s';
+							}
+							$date                        = get_date_from_gmt( $object[ $salesforce_field ], 'Y-m-d\TH:i:s\Z' ); // convert from GMT to local date/time based on WordPress time zone setting.
+							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $date ) );
 							break;
 						case ( in_array( $salesforce_field_type, $this->int_types_from_salesforce ) ):
 							$object[ $salesforce_field ] = isset( $object[ $salesforce_field ] ) ? (int) $object[ $salesforce_field ] : 0;

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -904,8 +904,9 @@ class Object_Sync_Sf_Mapping {
 							if ( 'tribe_events' === $mapping['wordpress_object'] && class_exists( 'Tribe__Events__Main' ) ) {
 								$format = 'Y-m-d H:i:s';
 							}
-							$date                        = get_date_from_gmt( $object[ $salesforce_field ], 'Y-m-d\TH:i:s\Z' ); // convert from GMT to local date/time based on WordPress time zone setting.
-							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $date ) );
+							// Note: the Salesforce REST API appears to always return dates as GMT values. We should retrieve them that way, then format them to deal with them in WordPress appropriately.
+							$gmt_date                    = get_date_from_gmt( $object[ $salesforce_field ], 'Y-m-d\TH:i:s\Z' ); // convert from GMT to local date/time based on WordPress time zone setting.
+							$object[ $salesforce_field ] = date_i18n( $format, strtotime( $gmt_date ) );
 							break;
 						case ( in_array( $salesforce_field_type, $this->int_types_from_salesforce ) ):
 							$object[ $salesforce_field ] = isset( $object[ $salesforce_field ] ) ? (int) $object[ $salesforce_field ] : 0;

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -1225,7 +1225,28 @@ class Object_Sync_Sf_WordPress {
 			$content['post_content'] = ' ';
 		}
 
-		$post_id = wp_insert_post( $content, true ); // return an error instead of a 0 id
+		if ( 'tribe_events' === $content['post_type'] && class_exists( 'Tribe__Events__Main' ) ) {
+			// borrowing some code from https://github.com/tacjtg/rhp-tribe-events/blob/master/rhp-tribe-events.php
+			if ( isset( $params['_EventStartDate'] ) ) {
+				$start_date                    = strtotime( $params['_EventStartDate']['value'] );
+				$content['EventStartDate']     = $start_date;
+				$content['EventStartHour']     = date( Tribe__Date_Utils::HOURFORMAT, $start_date );
+				$content['EventStartMinute']   = date( Tribe__Date_Utils::MINUTEFORMAT, $start_date );
+				$content['EventStartMeridian'] = date( Tribe__Date_Utils::MERIDIANFORMAT, $start_date );
+				unset( $params['_EventStartDate'] );
+			}
+			if ( isset( $params['_EventEndDate'] ) ) {
+				$end_date                    = strtotime( $params['_EventEndDate']['value'] );
+				$content['EventEndDate']     = $end_date;
+				$content['EventEndHour']     = date( Tribe__Date_Utils::HOURFORMAT, $end_date );
+				$content['EventEndMinute']   = date( Tribe__Date_Utils::MINUTEFORMAT, $end_date );
+				$content['EventEndMeridian'] = date( Tribe__Date_Utils::MERIDIANFORMAT, $end_date );
+				unset( $params['_EventEndDate'] );
+			}
+			$post_id = tribe_create_event( $content );
+		} else {
+			$post_id = wp_insert_post( $content, true ); // return an error instead of a 0 id
+		}
 
 		if ( is_wp_error( $post_id ) ) {
 			$success = false;

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -1225,22 +1225,14 @@ class Object_Sync_Sf_WordPress {
 			$content['post_content'] = ' ';
 		}
 
-		if ( 'tribe_events' === $content['post_type'] && class_exists( 'Tribe__Date_Utils' ) && function_exists( 'tribe_create_event' ) ) {
+		if ( 'tribe_events' === $content['post_type'] && function_exists( 'tribe_create_event' ) ) {
 			// borrowing some code from https://github.com/tacjtg/rhp-tribe-events/blob/master/rhp-tribe-events.php
 			if ( isset( $params['_EventStartDate'] ) ) {
-				$start_date                    = strtotime( $params['_EventStartDate']['value'] );
-				$content['EventStartDate']     = $start_date;
-				$content['EventStartHour']     = date( Tribe__Date_Utils::HOURFORMAT, $start_date );
-				$content['EventStartMinute']   = date( Tribe__Date_Utils::MINUTEFORMAT, $start_date );
-				$content['EventStartMeridian'] = date( Tribe__Date_Utils::MERIDIANFORMAT, $start_date );
+				$content = $this->append_tec_event_dates( $params['_EventStartDate']['value'], 'start', $content );
 				unset( $params['_EventStartDate'] );
 			}
 			if ( isset( $params['_EventEndDate'] ) ) {
-				$end_date                    = strtotime( $params['_EventEndDate']['value'] );
-				$content['EventEndDate']     = $end_date;
-				$content['EventEndHour']     = date( Tribe__Date_Utils::HOURFORMAT, $end_date );
-				$content['EventEndMinute']   = date( Tribe__Date_Utils::MINUTEFORMAT, $end_date );
-				$content['EventEndMeridian'] = date( Tribe__Date_Utils::MERIDIANFORMAT, $end_date );
+				$content = $this->append_tec_event_dates( $params['_EventEndDate']['value'], 'end', $content );
 				unset( $params['_EventEndDate'] );
 			}
 			$post_id = tribe_create_event( $content );
@@ -2575,6 +2567,29 @@ class Object_Sync_Sf_WordPress {
 	private function comment_delete( $id, $force_delete = false ) {
 		$result = wp_delete_comment( $id, $force_delete );
 		return $result;
+	}
+
+	/**
+	 * Generate date formats for The Event Calendar plugin
+	 *
+	 * @param datetime $date
+	 * @param string $type this should be start or end
+	 * @param array $content the other mapped params
+	 *
+	 * @return array $content
+	 */
+	private function append_tec_event_dates( $date, $type, $content ) {
+		if ( ( 'start' === $type || 'end' === $type ) && class_exists( 'Tribe__Date_Utils' ) ) {
+			$dates                                      = array();
+			$date_type                                  = ucfirst( $type );
+			$timestamp                                  = strtotime( $date );
+			$dates[ 'Event' . $date_type . 'Date' ]     = $timestamp;
+			$dates[ 'Event' . $date_type . 'Hour' ]     = date( Tribe__Date_Utils::HOURFORMAT, $timestamp );
+			$dates[ 'Event' . $date_type . 'Minute' ]   = date( Tribe__Date_Utils::MINUTEFORMAT, $timestamp );
+			$dates[ 'Event' . $date_type . 'Meridian' ] = date( Tribe__Date_Utils::MERIDIANFORMAT, $timestamp );
+			$content                                    = $content + $dates;
+		}
+		return $content;
 	}
 
 }

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -1225,7 +1225,7 @@ class Object_Sync_Sf_WordPress {
 			$content['post_content'] = ' ';
 		}
 
-		if ( 'tribe_events' === $content['post_type'] && class_exists( 'Tribe__Events__Main' ) ) {
+		if ( 'tribe_events' === $content['post_type'] && class_exists( 'Tribe__Date_Utils' ) && function_exists( 'tribe_create_event' ) ) {
 			// borrowing some code from https://github.com/tacjtg/rhp-tribe-events/blob/master/rhp-tribe-events.php
 			if ( isset( $params['_EventStartDate'] ) ) {
 				$start_date                    = strtotime( $params['_EventStartDate']['value'] );

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -2572,7 +2572,7 @@ class Object_Sync_Sf_WordPress {
 	/**
 	 * Generate date formats for The Event Calendar plugin
 	 *
-	 * @param datetime $date
+	 * @param string $date the string value of the date from Salesforce
 	 * @param string $type this should be start or end
 	 * @param array $content the other mapped params
 	 *


### PR DESCRIPTION
## What does this PR do?

This fixes #255 by providing basic support for saving Salesforce datetime fields in the patterns expected by The Event Calendar plugin. We need to make sure it doesn't conflict with ACF, CMB2, etc. methods of handling dates though.

## How do I test this PR?

- Install TEC plugin
- Map something from Salesforce to it. Good example is the default Event object.
- Install ACF/CMB2. Map some other event fields there and make sure there's no conflict.