### PR TITLE
Add object type parameter to push_update_params_modify hook

### DIFF
--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -890,7 +890,7 @@ class Object_Sync_Sf_Salesforce_Push {
 				// hook to allow other plugins to change params on update actions only
 				// use hook to map fields between the WordPress and Salesforce objects
 				// returns $params.
-				$params = apply_filters( $this->option_prefix . 'push_update_params_modify', $params, $salesforce_id, $mapping, $object );
+				$params = apply_filters( $this->option_prefix . 'push_update_params_modify', $params, $salesforce_id, $mapping, $object, $mapping['wordpress_object'] );
 
 				if ( isset( $prematch_field_wordpress ) || isset( $key_field_wordpress ) || null !== $salesforce_id ) {
 

--- a/docs/extending-parameters.md
+++ b/docs/extending-parameters.md
@@ -66,10 +66,12 @@ function change_push_params( $params, $mapping, $object, $sf_sync_trigger, $use_
 *   Mapping object.
 * @param array $object
 *   WordPress object data.
+* @param string $object_type
+*	WordPress object type.
 *
 */
-add_filter( 'object_sync_for_salesforce_push_update_params_modify', 'set_names_if_missing' ), 10, 4 );
-public function set_names_if_missing( $params, $salesforce_id, $mapping, $object ) {
+add_filter( 'object_sync_for_salesforce_push_update_params_modify', 'set_names_if_missing' ), 10, 5 );
+public function set_names_if_missing( $params, $salesforce_id, $mapping, $object, $object_type ) {
 	if ( null === $salesforce_id ) {
 		$params['FirstName'] = $object['first_name'];
 		$params['LastName']  = $object['last_name'];


### PR DESCRIPTION
## What does this PR do?

This adds the WordPress object type to the `push_update_params` hook. This allows developers using that hook to check what the WordPress object type is before modifying its data.

## How do I test this PR?

- write a function that uses the hook
- check the WP object type