### PR TITLE
271 object map permission issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The plugin documentation contains [initial setup instructions](https://github.co
 
 We make an effort to answer support requests in the [WordPress plugin forum](https://wordpress.org/support/plugin/object-sync-for-salesforce/). If you have these requests, please put them in that forum, not in this GitHub repository and not in anyone's email inbox.
 
+While MinnPost's nonprofit newsroom does welcome [donations](https://www.minnpost.com/support/?campaign=7010G0000012fXGQAY) to support our work, this plugin does not have a paid version.
+
 Use this repository for bugs, feature requests, etc. and especially do that if you can help solve these things.
 
 ## Finding other sync options

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,6 +42,18 @@ If the plugin allows you to authorize in Salesforce, but does not finish activat
 2. The plugin may have been unable to create its required database tables. If you think this may be the case, refer to [this document](./troubleshooting-unable-to-create-database-tables.md) for the necessary SQL.
 3. Mismatched settings between the plugin and the expected values in Salesforce.
 
+## Object map issues
+
+If you are successfully authenticated with Salesforce, but you are unable to create an object map, there are several ways to troubleshoot. Always check your PHP error logs first.
+
+### There are no Salesforce objects in the dropdown
+
+When there are no values in the list of Salesforce objects, this means the plugin can’t access any of the objects in your Salesforce. There are three likely causes for this:
+
+1. You need to change the OAuth scope on the app you created in Salesforce. For most uses with this plugin, you’ll want to use "Perform requests on your behalf at any time" and "Access and manage your data (api)."" If you do change these, you’ll need to wait several minutes before trying again, as Salesforce is rather slow on this.
+2. Your Salesforce objects might not be accessible to the Salesforce user who has authenticated with WordPress via this plugin.
+3. The Salesforce objects might have other restrictive permissions.
+
 ## Fieldmap issues
 
 If you are successfully authenticated with Salesforce, but you have a fieldmap that is not passing data, there are several ways to troubleshoot. Always check your PHP error logs first.

--- a/readme.txt
+++ b/readme.txt
@@ -247,6 +247,8 @@ There is extensive documentation of this plugin, including its developer hooks, 
 
 We make an effort to answer support requests in the [WordPress plugin forum](https://wordpress.org/support/plugin/object-sync-for-salesforce/). Please do not send them by email.
 
+While MinnPost's nonprofit newsroom does welcome [donations](https://www.minnpost.com/support/?campaign=7010G0000012fXGQAY) to support our work, this plugin does not have a paid version.
+
 ### Finding other options to sync Salesforce and WordPress
 
 This plugin can be relatively complicated, and sometimes other plugins can effectively integrate Salesforce and WordPress, especially if there are more limited, specific requirements. If one of these can meet those requirements, use it. We're happy to link to additional choices here, as well.

--- a/readme.txt
+++ b/readme.txt
@@ -200,7 +200,19 @@ If the plugin allows you to authorize in Salesforce, but does not finish activat
 2. The plugin may have been unable to create its required database tables. If you think this may be the case, refer to [this document](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/docs/troubleshooting-unable-to-create-database-tables.md) for the necessary SQL.
 3. Mismatched settings between the plugin and the expected values in Salesforce.
 
-### Troubleshooting Fieldmaps
+### Troubleshooting object maps
+
+If you are successfully authenticated with Salesforce, but you are unable to create object maps, there are several ways to troubleshoot. Always check your PHP error logs first. More information may be available in the [troubleshooting](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/docs/troubleshooting.md) section of the plugin's documentation.
+
+**There are no Salesforce objects in the dropdown**
+
+When there are no values in the list of Salesforce objects, this means the plugin can’t access any of the objects in your Salesforce. There are three likely causes for this:
+
+- You need to change the OAuth scope on the app you created in Salesforce. For most uses with this plugin, you’ll want to use "Perform requests on your behalf at any time" and "Access and manage your data (api)."" If you do change these, you’ll need to wait several minutes before trying again, as Salesforce is rather slow on this.
+- Your Salesforce objects might not be accessible to the Salesforce user who has authenticated with WordPress via this plugin.
+- The Salesforce objects might have other restrictive permissions.
+
+### Troubleshooting fieldmaps
 
 If you are successfully authenticated with Salesforce, but you have a fieldmap that is not passing data, there are several ways to troubleshoot. Always check your PHP error logs first. More information may be available in the [troubleshooting](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/docs/troubleshooting.md) section of the plugin's documentation.
 
@@ -230,6 +242,10 @@ We welcome contributions to this project from other developers. See our [contrib
 ### Plugin documentation
 
 There is extensive documentation of this plugin, including its developer hooks, [on GitHub](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/docs/readme.md).
+
+### Getting support using this plugin
+
+We make an effort to answer support requests in the [WordPress plugin forum](https://wordpress.org/support/plugin/object-sync-for-salesforce/). Please do not send them by email.
 
 ### Finding other options to sync Salesforce and WordPress
 

--- a/templates/admin/fieldmaps-add-edit-clone.php
+++ b/templates/admin/fieldmaps-add-edit-clone.php
@@ -26,7 +26,8 @@
 					} else {
 						$selected = '';
 					}
-					echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+					echo sprintf(
+						'<option value="%1$s"%2$s>%3$s</option>',
 						esc_html( $object ),
 						esc_attr( $selected ),
 						esc_html( $object )
@@ -59,7 +60,8 @@
 					} else {
 						$selected = '';
 					}
-					echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+					echo sprintf(
+						'<option value="%1$s"%2$s>%3$s</option>',
 						esc_html( $object['name'] ),
 						esc_attr( $selected ),
 						esc_html( $object['label'] )
@@ -67,6 +69,17 @@
 				}
 				?>
 			</select>
+			<?php if ( empty( $salesforce_objects ) ) : ?>
+				<p class="description">
+					<?php
+					echo sprintf(
+						// translators: 1) is the link to troubleshooting object maps in the plugin documentation
+						'<strong>' . esc_html__( 'The plugin is unable to access any Salesforce objects for object mapping.', 'object-sync-for-salesforce' ) . '</strong>' . esc_html__( ' This is most likely a permissions issue. See %1$s in the plugin documentation for more information and possible solutions.', 'object-sync-for-salesforce' ) . '</strong>',
+						'<a href="https://github.com/MinnPost/object-sync-for-salesforce/blob/271-object-map-permission-issues/docs/troubleshooting.md#object-map-issues">troubleshooting object maps</a>'
+					);
+					?>
+				</p>
+			<?php endif; ?>
 		</div>
 		<div class="salesforce_record_types_allowed">
 			<?php
@@ -88,7 +101,8 @@
 						} else {
 							$checked = '';
 						}
-						echo sprintf( '<label><input type="checkbox" class="form-checkbox" value="%1$s" name="%2$s" id="%3$s"%4$s>%5$s</label>',
+						echo sprintf(
+							'<label><input type="checkbox" class="form-checkbox" value="%1$s" name="%2$s" id="%3$s"%4$s>%5$s</label>',
 							esc_html( $key ),
 							esc_attr( 'salesforce_record_types_allowed[' . $key . ']' ),
 							esc_attr( 'salesforce_record_types_allowed-' . $key ),
@@ -122,7 +136,8 @@
 							$selected = '';
 						}
 						if ( ! isset( $salesforce_record_types_allowed ) || in_array( $key, $salesforce_record_types_allowed, true ) ) {
-							echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+							echo sprintf(
+								'<option value="%1$s"%2$s>%3$s</option>',
 								esc_attr( $key ),
 								esc_attr( $selected ),
 								esc_html( $value )
@@ -131,7 +146,7 @@
 					endforeach;
 					?>
 					</select>
-				<?php
+					<?php
 				endif;
 			endif;
 			?>
@@ -155,7 +170,8 @@
 					} else {
 						$selected = '';
 					}
-					echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+					echo sprintf(
+						'<option value="%1$s"%2$s>%3$s</option>',
 						esc_attr( $value['name'] ),
 						esc_attr( $selected ),
 						esc_html( $value['label'] )
@@ -186,7 +202,9 @@
 						<p><small>
 							<?php
 							// translators: the placeholders refer to: 1) the cache clear link, 2) the cache clear link text
-							echo sprintf( '<strong>' . esc_html__( 'Note:', 'object-sync-for-salesforce' ) . '</strong>' . esc_html__( ' to map a custom meta field (such as wp_postmeta, wp_usermeta, wp_termmeta, etc.), WordPress must have at least one value for that field. If you add a new meta field and want to map it, make sure to add a value for it and ', 'object-sync-for-salesforce' ) . '<a href="%1$s" id="clear-sfwp-cache">%2$s</a>' . esc_html__( ' to see the field listed here.', 'object-sync-for-salesforce' ),
+							echo sprintf(
+								'<strong>' .
+								esc_html__( 'Note:', 'object-sync-for-salesforce' ) . '</strong>' . esc_html__( ' to map a custom meta field (such as wp_postmeta, wp_usermeta, wp_termmeta, etc.), WordPress must have at least one value for that field. If you add a new meta field and want to map it, make sure to add a value for it and ', 'object-sync-for-salesforce' ) . '<a href="%1$s" id="clear-sfwp-cache">%2$s</a>' . esc_html__( ' to see the field listed here.', 'object-sync-for-salesforce' ),
 								esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=clear_cache' ) ),
 								esc_html__( 'clear the plugin cache', 'object-sync-for-salesforce' )
 							);
@@ -205,7 +223,7 @@
 				if ( isset( $fieldmap_fields ) && null !== $fieldmap_fields && is_array( $fieldmap_fields ) ) {
 					foreach ( $fieldmap_fields as $key => $value ) {
 						$key = md5( $key . time() );
-				?>
+						?>
 				<tr>
 					<td class="column-wordpress_field">
 						<select name="wordpress_field[<?php echo esc_attr( $key ); ?>]" id="wordpress_field-<?php echo esc_attr( $key ); ?>">
@@ -218,7 +236,8 @@
 								} else {
 									$selected = '';
 								}
-								echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+								echo sprintf(
+									'<option value="%1$s"%2$s>%3$s</option>',
 									esc_attr( $wordpress_field['key'] ),
 									esc_attr( $selected ),
 									esc_html( $wordpress_field['key'] )
@@ -257,7 +276,8 @@
 									$salesforce_field['label'] .= ' *';
 								}
 
-								echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+								echo sprintf(
+									'<option value="%1$s"%2$s>%3$s</option>',
 									esc_attr( $salesforce_field['name'] ),
 									esc_attr( $selected ),
 									esc_html( $salesforce_field['label'] )
@@ -319,10 +339,10 @@
 						<input type="checkbox" name="is_delete[<?php echo esc_attr( $key ); ?>]" id="is_delete-<?php echo esc_attr( $key ); ?>" value="1" />
 					</td>
 				</tr>
-				<?php
+						<?php
 					} // End foreach().
 				} elseif ( isset( $wordpress_object ) && isset( $salesforce_object ) ) {
-				?>
+					?>
 				<tr>
 					<td class="column-wordpress_field">
 						<select name="wordpress_field[0]" id="wordpress_field-0">
@@ -330,7 +350,8 @@
 							<?php
 							$wordpress_fields = $this->get_wordpress_object_fields( $wordpress_object );
 							foreach ( $wordpress_fields as $wordpress_field ) {
-								echo sprintf( '<option value="%1$s">%2$s</option>',
+								echo sprintf(
+									'<option value="%1$s">%2$s</option>',
 									esc_attr( $wordpress_field['key'] ),
 									esc_html( $wordpress_field['key'] )
 								);
@@ -348,7 +369,8 @@
 								)
 							);
 							foreach ( $salesforce_fields as $salesforce_field ) {
-								echo sprintf( '<option value="%1$s">%2$s</option>',
+								echo sprintf(
+									'<option value="%1$s">%2$s</option>',
 									esc_attr( $salesforce_field['name'] ),
 									esc_html( $salesforce_field['label'] )
 								);
@@ -373,7 +395,7 @@
 						<input type="checkbox" name="is_delete[0]" id="is_delete-0" value="1" />
 					</td>
 				</tr>
-				<?php
+					<?php
 				} // End if().
 				?>
 			</tbody>
@@ -460,5 +482,5 @@
 			// translators: the placeholder refers to the currently selected method (add, edit, or clone)
 			sprintf( esc_html__( '%1$s fieldmap', 'object-sync-for-salesforce' ), ucfirst( $method ) )
 		);
-	?>
+		?>
 </form>


### PR DESCRIPTION
## What does this PR do?

This fixes #271. Adds some documentation, and an inline link to the fieldmap add/edit screen, for permissions issues with object maps.

## How do I test this PR?

Probably the way to test this would be to create a Salesforce app with incorrect permissions and make sure the message shows up.