### PR TITLE
Pull Success Updates

### DIFF
--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -1048,9 +1048,12 @@ class Object_Sync_Sf_Salesforce_Push {
 				$mapping_object['salesforce_id']     = $salesforce_id;
 				$mapping_object['last_sync_message'] = esc_html__( 'Mapping object updated via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__;
 				$mapping_object_updated              = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+				
+				// save the mapping object to the synced object
+				$synced_object['mapping_object'] = $mapping_object;
 
 				// hook for push success
-				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $wordpress_id_field_name );
+				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $salesforce_id );
 			} else {
 
 				// create log entry for failed create or upsert

--- a/docs/extending-before-and-after-saving.md
+++ b/docs/extending-before-and-after-saving.md
@@ -113,7 +113,7 @@ function push_fail( $op, $response, $synced_object ) {
 #### After success
 
 ```php
-add_action( 'object_sync_for_salesforce_push_success', 'push_success', 10, 3 );
+add_action( 'object_sync_for_salesforce_push_success', 'push_success', 10, 4 );
 function push_success( $op, $response, $synced_object, $object_id ) {
     // do things if the save succeeded
     // $op is what the plugin did - Create, Update, Upsert, Delete


### PR DESCRIPTION
## What does this PR do?
Addresses the issues in #278
1) Update the documentation
2) Sets the $object_id to $salesforce_id
3) Copies the mapping object information into the synced object

## How do I test this PR?

1) Map a WordPress object to a Salesforce object
2) Add the example code to a custom plugin.
Modify the code to include a wp_mail call similar to:
wp_mail('your email', $op . ' - ' . $object_id, print_r($synced_object, true));
3) Create a new object in WordPress
4) Notice email has the new SF ID in the subject, and the mapping_object information is available in the $synced_object
