### PR TITLE
Fix docs links in All Developer Hooks

### DIFF
--- a/docs/all-developer-hooks.md
+++ b/docs/all-developer-hooks.md
@@ -55,19 +55,19 @@ This page lists all developer hooks available in this plugin, with links to wher
 - `object_sync_for_salesforce_settings_tabs`:
     - description: add tabs to the Salesforce Settings screen so they can have their own Salesforce-specific sections that fit within this overall plugin.
     - code: [classes/admin.php](../classes/admin.php)
-    - documentation: [add a settings tab](./docs/adding-settings.md#add-a-settings-tab)
+    - documentation: [add a settings tab](./adding-settings.md#add-a-settings-tab)
 - `object_sync_for_salesforce_settings_tab_include_settings`:
     - description: when adding tabs to the Salesforce Settings screen, determine whether or not to include the default settings PHP template, which we use to render the form.
     - code: [classes/admin.php](../classes/admin.php)
-    - documentation: [change the template](./docs/adding-settings.md#change-the-template)
+    - documentation: [change the template](./adding-settings.md#change-the-template)
 - `object_sync_for_salesforce_settings_tab_content_before`:
     - description: when adding tabs to the Salesforce Settings screen, send additional content to display before the settings form.
     - code: [classes/admin.php](../classes/admin.php)
-    - documentation: [adding settings](./docs/adding-settings.md#add-content-to-a-tab)
+    - documentation: [adding settings](./adding-settings.md#add-content-to-a-tab)
 - `object_sync_for_salesforce_settings_tab_content_after`:
     - description: when adding tabs to the Salesforce Settings screen, send additional content to display after the settings form.
     - code: [classes/admin.php](../classes/admin.php)
-    - documentation: [adding settings](./docs/adding-settings.md#add-content-to-a-tab)
+    - documentation: [adding settings](./adding-settings.md#add-content-to-a-tab)
 - `object_sync_for_salesforce_modify_schedulable_classes`:
     - description: modify the array of schedulable classes. This is the list of classes that can use the `schedule` class to run a queue of scheduled tasks.
     - code: [object-sync-for-salesforce.php](../../object-sync-for-salesforce.php)

--- a/docs/all-developer-hooks.md
+++ b/docs/all-developer-hooks.md
@@ -70,11 +70,11 @@ This page lists all developer hooks available in this plugin, with links to wher
     - documentation: [adding settings](./adding-settings.md#add-content-to-a-tab)
 - `object_sync_for_salesforce_modify_schedulable_classes`:
     - description: modify the array of schedulable classes. This is the list of classes that can use the `schedule` class to run a queue of scheduled tasks.
-    - code: [object-sync-for-salesforce.php](../../object-sync-for-salesforce.php)
+    - code: [object-sync-for-salesforce.php](../object-sync-for-salesforce.php)
     - documentation: [extending scheduling](./extending-scheduling.md)
 - `object_sync_for_salesforce_select_library`:
 	- description: modify the `select` library used for choosing WordPress and Salesforce fields on fieldmaps. By default, we add the selectWoo library.
-	- code: [object-sync-for-salesforce.php](../../object-sync-for-salesforce.php)
+	- code: [object-sync-for-salesforce.php](../object-sync-for-salesforce.php)
 	- documentation: [extending mapping options](./extending-mapping-options.md#administration-interface)
 - `object_sync_for_salesforce_add_more_wordpress_types`:
     - description: add additional WordPress content types to the list of what can be mapped to Salesforce objects.


### PR DESCRIPTION
## What does this PR do?
Fixes broken links in the All Developer Hooks Docs page
## How do I test this PR?
- Go to Docs page docs/all-developer-hooks.mdLinks 
- Four links fixed for Settings pages
  - object_sync_for_salesforce_settings_tab
    - documentation: add a settings tab
  - object_sync_for_salesforce_settings_tab_include_settings
    - documentation: change the template
  - object_sync_for_salesforce_settings_tab_content_before 
    - documentation: adding settings 
  - object_sync_for_salesforce_settings_tab_content_after 
    - documentation: adding settings

Two links fixed to main class
- object_sync_for_salesforce_modify_schedulable_classes
  -  code: object-sync-for-salesforce.php
- object_sync_for_salesforce_select_library
  - code: object-sync-for-salesforce.php

