### PR TITLE
# 285 Adds Salesforce info block to admins own profile

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -162,6 +162,7 @@ class Object_Sync_Sf_Admin {
 		add_action( 'wp_ajax_clear_sfwp_cache', array( $this, 'clear_sfwp_cache' ) );
 
 		add_action( 'edit_user_profile', array( $this, 'show_salesforce_user_fields' ) );
+		add_action( 'show_user_profile', array( $this, 'show_salesforce_user_fields' ) );
 		add_action( 'personal_options_update', array( $this, 'save_salesforce_user_fields' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'save_salesforce_user_fields' ) );
 


### PR DESCRIPTION
## What does this PR do?
Resolves Issue #285 and kets an admin see their own Salesforce data in User -> "Your Profile"
## How do I test this PR?

- select User -> "Your Profile"
- view your Salesforce Info

