### PR TITLE
Make the logs sortable and filterable by the type value

### DIFF
--- a/classes/logging.php
+++ b/classes/logging.php
@@ -185,15 +185,19 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 		global $pagenow;
 		$type     = 'wp_log';
 		$taxonomy = 'wp_log_type';
-		if ( is_admin() && isset( $_GET['post_type'] ) && esc_attr( $_GET['post_type'] ) === $type && 'edit.php' === $pagenow && isset( $_GET[ $taxonomy ] ) && '' !== $_GET[ $taxonomy ] ) {
-			$query->post_type = $type;
-			$query->tax_query = array(
-				array(
-					'taxonomy' => $taxonomy,
-					'field'    => 'slug',
-					'terms'    => esc_attr( $_GET[ $taxonomy ] ),
-				),
-			);
+		if ( is_admin() && 'edit.php' === $pagenow ) {
+			if ( isset( $_GET['post_type'] ) && esc_attr( $_GET['post_type'] ) === $type ) {
+				if ( isset( $_GET[ $taxonomy ] ) && '' !== $_GET[ $taxonomy ] ) {
+					$query->post_type = $type;
+					$query->tax_query = array(
+						array(
+							'taxonomy' => $taxonomy,
+							'field'    => 'slug',
+							'terms'    => esc_attr( $_GET[ $taxonomy ] ),
+						),
+					);
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## What does this PR do?

This fixes #287. We have a sortable column in the list of log entries that shows the log type. In addition, we can filter the logs by the log type.

## How do I test this PR?

- Create some logs
- Filter them by the log type (in this case, salesforce)
- Optional: use another plugin to make more log entries, and filter them as well.