### PR TITLE
Unify push success hook parameters

### DIFF
--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -1053,7 +1053,7 @@ class Object_Sync_Sf_Salesforce_Push {
 				$synced_object['mapping_object'] = $mapping_object;
 
 				// hook for push success
-				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $salesforce_id, $object[ "$wordpress_id_field_name" ] );
+				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $salesforce_id, $wordpress_id_field_name );
 			} else {
 
 				// create log entry for failed create or upsert

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -752,7 +752,7 @@ class Object_Sync_Sf_Salesforce_Push {
 						$logging->setup( $result );
 
 						// hook for push success
-						do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $wordpress_id_field_name );
+						do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $mapping_object['salesforce_id'], $wordpress_id_field_name );
 					}
 				} else {
 					$more_ids = __( '<p>The Salesforce record was not deleted because there are multiple WordPress IDs that match this Salesforce ID. They are:</p>', 'object-sync-for-salesforce' );
@@ -1053,7 +1053,7 @@ class Object_Sync_Sf_Salesforce_Push {
 				$synced_object['mapping_object'] = $mapping_object;
 
 				// hook for push success
-				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $salesforce_id );
+				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $salesforce_id, $object[ "$wordpress_id_field_name" ] );
 			} else {
 
 				// create log entry for failed create or upsert
@@ -1188,7 +1188,7 @@ class Object_Sync_Sf_Salesforce_Push {
 				$logging->setup( $result );
 
 				// hook for push success
-				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $wordpress_id_field_name );
+				do_action( $this->option_prefix . 'push_success', $op, $sfapi->response, $synced_object, $mapping_object['salesforce_id'], $wordpress_id_field_name );
 
 			} catch ( Object_Sync_Sf_Exception $e ) {
 				// create log entry for failed update

--- a/docs/extending-before-and-after-saving.md
+++ b/docs/extending-before-and-after-saving.md
@@ -113,8 +113,8 @@ function push_fail( $op, $response, $synced_object ) {
 #### After success
 
 ```php
-add_action( 'object_sync_for_salesforce_push_success', 'push_success', 10, 4 );
-function push_success( $op, $response, $synced_object, $object_id ) {
+add_action( 'object_sync_for_salesforce_push_success', 'push_success', 10, 5 );
+function push_success( $op, $response, $synced_object, $object_id, $wordpress_id_field_name ) {
     // do things if the save succeeded
     // $op is what the plugin did - Create, Update, Upsert, Delete
     // $response is what was returned by the $salesforce class. sfapi->response
@@ -128,5 +128,6 @@ function push_success( $op, $response, $synced_object, $object_id ) {
     );
     */
     // $object_id is the salesforce object id
+    // $wordpress_id_field_name is the name of the ID field in WordPress
 }
 ```


### PR DESCRIPTION
## What does this PR do?

This makes the `object_sync_for_salesforce_push_success` hook have consistent parameters across all the places where it's called, and updates the documentation to match it. This is backward compatible as far as the docs are concerned. It also applies the #278 order on all the instances of this hook.