### PR TITLE
Provide an optional setting for how many log entries to clear

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1064,6 +1064,19 @@ class Object_Sync_Sf_Admin {
 					),
 				),
 			),
+			'logs_how_many_number'  => array(
+				'title'    => __( 'Clear this many log entries', 'object-sync-for-salesforce' ),
+				'callback' => $callbacks['text'],
+				'page'     => $page,
+				'section'  => $section,
+				'args'     => array(
+					'type'     => 'number',
+					'validate' => 'absint',
+					'desc'     => __( 'This number is how many log entries the plugin will try to clear at a time. If you do not enter a number, the default is 100.', 'object-sync-for-salesforce' ),
+					'default'  => '100',
+					'constant' => '',
+				),
+			),
 			'triggers_to_log'       => array(
 				'title'    => __( 'Triggers to log', 'object-sync-for-salesforce' ),
 				'callback' => $callbacks['checkboxes'],

--- a/classes/logging.php
+++ b/classes/logging.php
@@ -402,6 +402,10 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 	 */
 	public function set_prune_args( $args ) {
 		$args['wp_log_type'] = 'salesforce';
+		$number_to_prune     = get_option( $this->option_prefix . 'logs_how_many_number', '' );
+		if ( '' !== $number_to_prune ) {
+			$args['posts_per_page'] = filter_var( $number_to_prune, FILTER_SANITIZE_NUMBER_INT );
+		}
 		return $args;
 	}
 


### PR DESCRIPTION
## What does this PR do?

This adds a settings field to the Log settings tab. If present, this is what the log prune task will use to tell how many log entries to clear. This fixes #294.

## How do I test this PR?

- change the settings for log clearing
- the plugin should clear that many entries