### PR TITLE
Fix authorize settings tab to prevent errors when there are no Salesforce Contacts

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -2018,14 +2018,20 @@ class Object_Sync_Sf_Admin {
 			$contacts_refreshed_token = esc_html__( 'This request did not require refreshing the Salesforce token', 'object-sync-salesforce' );
 		}
 
-		// translators: 1) $contacts['data']['totalSize'] is the number of items loaded, 2) $contacts['data']['records'][0]['attributes']['type'] is the name of the Salesforce object, 3) $contacts_is_cached is the "They are/are not cached, and/but" line, 4) $contacts_from_cache is the "they were/were not loaded from the cache" line, 5) is the "this request did/did not require refreshing the Salesforce token" line
-		$contacts_apicall_summary = sprintf( esc_html__( 'Salesforce successfully returned %1$s %2$s records. %3$s %4$s. %5$s.', 'object-sync-for-salesforce' ),
-			absint( $contacts['data']['totalSize'] ),
-			esc_html( $contacts['data']['records'][0]['attributes']['type'] ),
-			$contacts_is_cached,
-			$contacts_from_cache,
-			$contacts_refreshed_token
-		);
+		// display contact summary if there are any contacts
+		if ( 0 < absint( $contacts['data']['totalSize'] ) ) {
+			$contacts_apicall_summary = sprintf(
+				// translators: 1) $contacts['data']['totalSize'] is the number of items loaded, 2) $contacts['data']['records'][0]['attributes']['type'] is the name of the Salesforce object, 3) $contacts_is_cached is the "They are/are not cached, and/but" line, 4) $contacts_from_cache is the "they were/were not loaded from the cache" line, 5) is the "this request did/did not require refreshing the Salesforce token" line
+				esc_html__( 'Salesforce successfully returned %1$s %2$s records. %3$s %4$s. %5$s.', 'object-sync-for-salesforce' ),
+				absint( $contacts['data']['totalSize'] ),
+				esc_html( $contacts['data']['records'][0]['attributes']['type'] ),
+				$contacts_is_cached,
+				$contacts_from_cache,
+				$contacts_refreshed_token
+			);
+		} else {
+			$contacts_apicall_summary = '';
+		}
 
 		require_once( plugin_dir_path( __FILE__ ) . '/../templates/admin/status.php' );
 

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -1,11 +1,12 @@
 <h3><?php echo esc_html__( 'Salesforce Status', 'object-sync-for-salesforce' ); ?></h3>
 <p>
 <?php
-	// translators: placeholder is for the version number of the Salesforce REST API
-	echo sprintf( esc_html__( 'Currently, we are using version %1$s of the Salesforce REST API. Available versions are displayed below.', 'object-sync-for-salesforce' ),
+	echo sprintf(
+		// translators: placeholder is for the version number of the Salesforce REST API
+		esc_html__( 'Currently, we are using version %1$s of the Salesforce REST API. Available versions are displayed below.', 'object-sync-for-salesforce' ),
 		esc_html( $this->login_credentials['rest_api_version'] )
 	);
-?>
+	?>
 </p>
 <table class="widefat striped">
 	<thead>
@@ -35,22 +36,24 @@
 	</tbody>
 </table>
 
-<table class="widefat striped">
-	<thead>
-		<summary>
-			<h4><?php echo $contacts_apicall_summary; ?></h4>
-		</summary>
-		<tr>
-			<th><?php echo esc_html__( 'Contact ID' ); ?></th>
-			<th><?php echo esc_html__( 'Name' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php foreach ( $contacts['data']['records'] as $contact ) { ?>
+<?php if ( '' !== $contacts_apicall_summary ) : ?>
+	<table class="widefat striped">
+		<thead>
+			<summary>
+				<h4><?php echo $contacts_apicall_summary; ?></h4>
+			</summary>
 			<tr>
-				<td><?php echo esc_html( $contact['Id'] ); ?></td>
-				<td><?php echo esc_html( $contact['Name'] ); ?></td>
+				<th><?php echo esc_html__( 'Contact ID' ); ?></th>
+				<th><?php echo esc_html__( 'Name' ); ?></th>
 			</tr>
-		<?php } ?>
-	</tbody>
-</table>
+		</thead>
+		<tbody>
+			<?php foreach ( $contacts['data']['records'] as $contact ) { ?>
+				<tr>
+					<td><?php echo esc_html( $contact['Id'] ); ?></td>
+					<td><?php echo esc_html( $contact['Name'] ); ?></td>
+				</tr>
+			<?php } ?>
+		</tbody>
+	</table>
+<?php endif; ?>


### PR DESCRIPTION
## What does this PR do?
This fixes the plugin's Authorize tab if the connected Salesforce instance has no Contact records.

## How do I test this PR?

1. Install/active the plugin.
2. Authorize it with a Salesforce instance that has no Contacts.
3. Go to the Authorize tab. There shouldn't be an error.
4. Add some Contacts. They should display as normal.