### PR TITLE
Adding object type to wordpress_object_data filter

### DIFF
--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -381,7 +381,7 @@ class Object_Sync_Sf_WordPress {
 			}
 		*/
 
-		$wordpress_object = apply_filters( $this->option_prefix . 'wordpress_object_data', $wordpress_object );
+		$wordpress_object = apply_filters( $this->option_prefix . 'wordpress_object_data', $wordpress_object, $object_type );
 
 		return $wordpress_object;
 

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -374,9 +374,13 @@ class Object_Sync_Sf_WordPress {
 		 * This is useful for custom objects, hidden fields, or custom formatting.
 		 * Here's an example of filters to add/modify data:
 		 *
-			add_filter( 'object_sync_for_salesforce_wordpress_object_data', 'modify_data', 10, 1 );
-			function modify_data( $wordpress_object ) {
+			add_filter( 'object_sync_for_salesforce_wordpress_object_data', 'modify_data', 10, 2 );
+			function modify_data( $wordpress_object, $object_type ) {
 				$wordpress_object['field_a'] = 'i am a field value that salesforce wants to store but WordPress does not care about';
+				// Add field values to specific WordPress objects such as 'post', 'page', 'user', a Custom Post Type, etc.
+				if ($object_type === 'user') {
+					$wordpress_object['field_b'] = 'i am a field value that salesforce wants to store but WordPress does not care about';
+				}
 				return $wordpress_object;
 			}
 		*/

--- a/docs/extending-mapping-options.md
+++ b/docs/extending-mapping-options.md
@@ -175,9 +175,13 @@ To modify the array, you can use the `object_sync_for_salesforce_wordpress_objec
 Code example:
 
 ```php
-add_filter( 'object_sync_for_salesforce_wordpress_object_data', 'add_data', 10, 1 );
-function add_data( $wordpress_object ) {
+add_filter( 'object_sync_for_salesforce_wordpress_object_data', 'add_data', 10, 2 );
+function add_data( $wordpress_object, $object_type ) {
     $wordpress_object['field_a'] = 'i am a field value that salesforce wants to store but WordPress does not care about';
+    // Add field values to specific WordPress objects such as 'post', 'page', 'user', a Custom Post Type, etc.
+    if ($object_type === 'user') {
+        $wordpress_object['field_b'] = 'i am a field value that salesforce wants to store but WordPress does not care about';
+    }
     return $wordpress_object;
 }
 ```


### PR DESCRIPTION
## What does this PR do?

Sending the current object type to the WordPress action so we know what type is currently being used while sending it to Salesforce. This allows us to alter WordPress data by current object.
