### PR TITLE
use the log entry status variable in the title of all the log entries

### DIFF
--- a/classes/salesforce.php
+++ b/classes/salesforce.php
@@ -323,8 +323,10 @@ class Object_Sync_Sf_Salesforce {
 				$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
 			}
 
-			// translators: placeholder is the URL of the Salesforce API request
-			$title = sprintf( esc_html__( 'Debug: on Salesforce API HTTP Request to URL: %1$s.', 'object-sync-for-salesforce' ),
+			$title = sprintf(
+				// translators: placeholders are: 1) the log status, 2) the URL of the Salesforce API request
+				esc_html__( '%1$s: on Salesforce API HTTP Request to URL: %2$s.', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_url( $url )
 			);
 
@@ -434,9 +436,11 @@ class Object_Sync_Sf_Salesforce {
 					$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
 				}
 
-				// translators: placeholder is the HTTP status code returned by the Salesforce API request
-				$title = sprintf( esc_html__( 'Error: %1$s: on Salesforce http request', 'object-sync-for-salesforce' ),
-					esc_attr( $code )
+				$title = sprintf(
+					// translators: placeholders are: 1) the log status, 2) the HTTP status code returned by the Salesforce API request
+					esc_html__( '%1$s: %2$s: on Salesforce HTTP request', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
+					absint( $code )
 				);
 
 				$logging->setup(
@@ -456,13 +460,16 @@ class Object_Sync_Sf_Salesforce {
 					$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
 				}
 
-				// translators: placeholder is the server code returned by the api
-				$title = sprintf( esc_html__( 'Error: %1$s: on Salesforce http request', 'object-sync-for-salesforce' ),
+				$title = sprintf(
+					// translators: placeholders are: 1) the log status, 2) the HTTP status code returned by the Salesforce API request
+					esc_html__( '%1$s: %2$s: on Salesforce HTTP request', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					absint( $code )
 				);
 
-				// translators: placeholders are: 1) the URL requested, 2) the message returned by the error, 3) the server code returned
-				$body = sprintf( '<p>' . esc_html__( 'URL: %1$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: %2$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Code: %3$s', 'object-sync-for-salesforce' ),
+				$body = sprintf(
+					// translators: placeholders are: 1) the URL requested, 2) the message returned by the error, 3) the server code returned
+					'<p>' . esc_html__( 'URL: %1$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: %2$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Code: %3$s', 'object-sync-for-salesforce' ),
 					esc_attr( $url ),
 					esc_html( $data[0]['message'] ),
 					absint( $code )
@@ -485,8 +492,10 @@ class Object_Sync_Sf_Salesforce {
 					$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
 				}
 
-				// translators: placeholder is the server code returned by Salesforce
-				$title = sprintf( esc_html__( 'Error: %1$s: on Salesforce http request', 'object-sync-for-salesforce' ),
+				$title = sprintf(
+					// translators: placeholders are: 1) the log status, 2) the HTTP status code returned by the Salesforce API request
+					esc_html__( '%1$s: %2$s: on Salesforce HTTP request', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					absint( $code )
 				);
 

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -446,8 +446,9 @@ class Object_Sync_Sf_Mapping {
 			}
 			$logging->setup(
 				sprintf(
-					// translators: %1$s is the name of a WordPress object. %2$s is the id of that object.
-					esc_html__( 'Error Mapping: error caused by trying to map the WordPress %1$s with ID of %2$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
+					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
+					esc_html__( '%1$s Mapping: error caused by trying to map the WordPress %2$s with ID of %3$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $data['wordpress_object'] ),
 					absint( $data['wordpress_id'] )
 				),
@@ -472,8 +473,9 @@ class Object_Sync_Sf_Mapping {
 			}
 			$logging->setup(
 				sprintf(
-					// translators: %1$s is the status word "Error". %1$s is the Id of a Salesforce object. %2$s is the ID of a mapping object.
-					esc_html__( 'Error: Mapping: there is already a WordPress object mapped to the Salesforce object %1$s and the mapping object ID is %2$s', 'object-sync-for-salesforce' ),
+					// translators: %1$s is the status word "Error". %2$s is the Id of a Salesforce object. %3$s is the ID of a mapping object.
+					esc_html__( '%1$s: Mapping: there is already a WordPress object mapped to the Salesforce object %2$s and the mapping object ID is %3$s', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $data['salesforce_id'] ),
 					absint( $id )
 				),

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -259,7 +259,11 @@ class Object_Sync_Sf_Salesforce_Pull {
 			if ( 1 === (int) $this->debug ) {
 				// create log entry for the attempted query
 				$status = 'debug';
-				$title  = esc_html__( 'Debug: SOQL query to get updated records from Salesforce (it has not yet run)', 'object-sync-for-salesforce' );
+				$title  = sprintf(
+					// translators: placeholders are: 1) the log status
+					esc_html__( '%1$s: SOQL query to get updated records from Salesforce (it has not yet run)', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) )
+				);
 
 				if ( isset( $this->logging ) ) {
 					$logging = $this->logging;
@@ -300,8 +304,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 							// create log entry for failed pull
 							$status = 'debug';
 							$title  = sprintf(
-								// translators: placeholders are: 1) the Salesforce ID
-								esc_html__( 'Debug: Salesforce ID %1$s has already been attempted.', 'object-sync-for-salesforce' ),
+								// translators: placeholders are: 1) the log status, 2) the Salesforce ID
+								esc_html__( '%1$s: Salesforce ID %2$s has already been attempted.', 'object-sync-for-salesforce' ),
+								ucfirst( esc_attr( $status ) ),
 								esc_attr( $result['Id'] )
 							);
 
@@ -351,8 +356,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 								// create log entry for failed pull
 								$status = 'debug';
 								$title  = sprintf(
-									// translators: placeholders are: 1) the Salesforce ID
-									esc_html__( 'Debug: Salesforce ID %1$s is not allowed.', 'object-sync-for-salesforce' ),
+									// translators: placeholders are: 1) the log status, 2) the Salesforce ID
+									esc_html__( '%1$s: Salesforce ID %2$s is not allowed.', 'object-sync-for-salesforce' ),
+									ucfirst( esc_attr( $status ) ),
 									esc_attr( $result['Id'] )
 								);
 
@@ -379,8 +385,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 							// create log entry for queue addition
 							$status = 'debug';
 							$title  = sprintf(
-								// translators: placeholders are: 1) the Salesforce ID
-								esc_html__( 'Debug: Add Salesforce ID %1$s to the queue', 'object-sync-for-salesforce' ),
+								// translators: placeholders are: 1) the log status, 2) the Salesforce ID
+								esc_html__( '%1$s: Add Salesforce ID %2$s to the queue', 'object-sync-for-salesforce' ),
+								ucfirst( esc_attr( $status ) ),
 								esc_attr( $result['Id'] )
 							);
 
@@ -427,8 +434,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 							// create log entry for successful pull
 							$status = 'debug';
 							$title  = sprintf(
-								// translators: placeholders are: 1) the Salesforce ID
-								esc_html__( 'Debug: Salesforce ID %1$s has been successfully pulled.', 'object-sync-for-salesforce' ),
+								// translators: placeholders are: 1) the log status, 2) the Salesforce ID
+								esc_html__( '%1$s: Salesforce ID %2$s has been successfully pulled.', 'object-sync-for-salesforce' ),
+								ucfirst( esc_attr( $status ) ),
 								esc_attr( $result['Id'] )
 							);
 
@@ -482,8 +490,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 				// create log entry for failed pull
 				$status = 'error';
 				$title  = sprintf(
-					// translators: placeholders are: 1) the server error code, and 2) the name of the Salesforce object
-					esc_html__( 'Error: %1$s when pulling %2$s data from Salesforce', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status, 2) the server error code, and 3) the name of the Salesforce object
+					esc_html__( '%1$s: %2$s when pulling %3$s data from Salesforce', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					absint( $response['errorCode'] ),
 					esc_attr( $salesforce_mapping['salesforce_object'] )
 				);
@@ -905,8 +914,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 				}
 
 				$title = sprintf(
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object type, 3) the previous Salesforce Id value, 4) the new Salesforce Id value, 5) the name of the WordPress object, 6) the WordPress id value
-					esc_html__( 'Success: %1$s Salesforce %2$s objects with Ids %3$s and %4$s were merged (%4$s is the remaining ID. It is mapped to WordPress %5$s with %6$s.)', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object type, 4) the previous Salesforce Id value, 5) the new Salesforce Id value, 6) the name of the WordPress object, 7) the WordPress id value
+					esc_html__( '%1$s: %2$s Salesforce %3$s objects with Ids %4$s and %5$s were merged (%5$s is the remaining ID. It is mapped to WordPress %6$s with %7$s.)', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $op ),
 					esc_attr( $object_type ),
 					esc_attr( $previous_sf_id ),
@@ -1132,7 +1142,11 @@ class Object_Sync_Sf_Salesforce_Pull {
 				if ( 1 === (int) $this->debug ) {
 					// create log entry for failed pull
 					$status = 'debug';
-					$title  = esc_html__( 'Debug: we are missing a deletedDate attribute here, but are expected to delete an item.', 'object-sync-for-salesforce' );
+					$title  = sprintf(
+						// translators: placeholders are: 1) the log status
+						esc_html__( '%1$s: we are missing a deletedDate attribute here, but are expected to delete an item.', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) )
+					);
 
 					if ( isset( $this->logging ) ) {
 						$logging = $this->logging;
@@ -1195,8 +1209,11 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 				}
 
-				$title = sprintf( esc_html__( 'Error: Salesforce Pull: unable to process queue item because it has no Salesforce Id.', 'object-sync-for-salesforce' ) );
-
+				$title = sprintf(
+					// translators: placeholders are: 1) the log status
+					esc_html__( '%1$s: Salesforce Pull: unable to process queue item because it has no Salesforce Id.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) )
+				);
 				$result = array(
 					'title'   => $title,
 					'message' => print_r( $object, true ), // log whatever we have in the event of this error, so print the array
@@ -1260,8 +1277,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 					// create log entry for failed pull
 					$status = 'debug';
 					$title  = sprintf(
-						// translators: placeholders are: 1) the mapping object ID transient
-						esc_html__( 'Debug: mapping object transient ID %1$s is currently pushing, so we do not pull it.', 'object-sync-for-salesforce' ),
+						// translators: placeholders are: 1) the log status, 2) the mapping object ID transient
+						esc_html__( '%1$s: mapping object transient ID %2$s is currently pushing, so we do not pull it.', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) ),
 						$mapping_object_id_transient
 					);
 
@@ -1507,7 +1525,11 @@ class Object_Sync_Sf_Salesforce_Pull {
 					if ( array() !== $mapping_object_debug ) {
 						// create log entry to warn about at least one id of 0
 						$status = 'error';
-						$title  = sprintf( esc_html__( 'Error: There is at least one object map with a WordPress ID of 0.', 'object-sync-for-salesforce' ) );
+						$title  = sprintf(
+							// translators: placeholders are: 1) the log status
+							esc_html__( '%1$s: There is at least one object map with a WordPress ID of 0.', 'object-sync-for-salesforce' ),
+							ucfirst( esc_attr( $status ) )
+						);
 
 						if ( 1 === count( $mapping_object_debug ) ) {
 							$body = sprintf(
@@ -1560,8 +1582,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 					// create log entry to indicate that nothing happened
 					$status = 'notice';
 					$title  = sprintf(
-						// translators: placeholders are: 1) mapping object row id, 2) WordPress object tyoe, 3) individual WordPress item ID, 4) individual Salesforce item ID
-						esc_html__( 'Notice: Because object map %1$s already exists, WordPress %2$s %3$s was not mapped to Salesforce Id %4$s', 'object-sync-for-salesforce' ),
+						// translators: placeholders are: 1) log status, 2) mapping object row id, 3) WordPress object tyoe, 4) individual WordPress item ID, 5) individual Salesforce item ID
+						esc_html__( '%1$s: Because object map %2$s already exists, WordPress %3$s %4$s was not mapped to Salesforce Id %5$s', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) ),
 						absint( $mapping_object['id'] ),
 						esc_attr( $salesforce_mapping['wordpress_object'] ),
 						absint( $wordpress_id ),
@@ -1640,8 +1663,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 			// create log entry for failed create or upsert
 			$status = 'error';
 			$title  = sprintf(
-				// translators: placeholders are: 1) what operation is happening, and 2) the name of the WordPress object
-				esc_html__( 'Error: %1$s WordPress %2$s', 'object-sync-for-salesforce' ),
+				// translators: placeholders are: 1) the log status, 2) what operation is happening, and 3) the name of the WordPress object
+				esc_html__( '%1$s: %2$s WordPress %3$s', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $op ),
 				esc_attr( $salesforce_mapping['wordpress_object'] )
 			);
@@ -1719,8 +1743,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 			}
 
 			$title = sprintf(
-				// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-				esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s Id of %6$s)', 'object-sync-for-salesforce' ),
+				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value
+				esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (Salesforce %6$s Id of %7$s)', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $op ),
 				esc_attr( $salesforce_mapping['wordpress_object'] ),
 				esc_attr( $wordpress_id_field_name ),
@@ -1765,8 +1790,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 			}
 
 			$title = sprintf(
-				// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object type, 3) the Salesforce object Id value
-				esc_html__( 'Error syncing: %1$s to WordPress (Salesforce %2$s Id %3$s)', 'object-sync-for-salesforce' ),
+				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object type, 4) the Salesforce object Id value
+				esc_html__( '%1$s syncing: %2$s to WordPress (Salesforce %3$s Id %4$s)', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $op ),
 				esc_attr( $salesforce_mapping['salesforce_object'] ),
 				esc_attr( $object['Id'] )
@@ -1855,8 +1881,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 			}
 
 			$title = sprintf(
-				// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-				esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s Id of %6$s)', 'object-sync-for-salesforce' ),
+				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value
+				esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (Salesforce %6$s Id of %7$s)', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $op ),
 				esc_attr( $salesforce_mapping['wordpress_object'] ),
 				esc_attr( $wordpress_id_field_name ),
@@ -1890,8 +1917,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 			}
 
 			$title .= sprintf(
-				// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-				esc_html__( 'Error: %1$s WordPress %2$s with %3$s of %4$s (Salesforce %5$s with Id of %6$s)', 'object-sync-for-salesforce' ),
+				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value
+				esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (Salesforce %6$s with Id of %7$s)', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $op ),
 				esc_attr( $salesforce_mapping['wordpress_object'] ),
 				esc_attr( $wordpress_id_field_name ),
@@ -1994,8 +2022,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 						}
 
 						$title = sprintf(
-							// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-							esc_html__( 'Error: %1$s WordPress %2$s with %3$s of %4$s (%5$s %6$s)', 'object-sync-for-salesforce' ),
+							// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value
+							esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (%6$s %7$s)', 'object-sync-for-salesforce' ),
+							ucfirst( esc_attr( $status ) ),
 							esc_attr( $op ),
 							esc_attr( $salesforce_mapping['wordpress_object'] ),
 							esc_attr( $wordpress_id_field_name ),
@@ -2041,8 +2070,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 						}
 
 						$title = sprintf(
-							// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object, 6) the Salesforce Id value
-							esc_html__( 'Success: %1$s WordPress %2$s with %3$s of %4$s (%5$s %6$s)', 'object-sync-for-salesforce' ),
+							// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value
+							esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (%6$s %7$s)', 'object-sync-for-salesforce' ),
+							ucfirst( esc_attr( $status ) ),
 							esc_attr( $op ),
 							esc_attr( $salesforce_mapping['wordpress_object'] ),
 							esc_attr( $wordpress_id_field_name ),
@@ -2091,7 +2121,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					$title = sprintf(
 						// translators: placeholders are: 1) the operation that is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object type, 6) the Salesforce Id
-						esc_html__( 'Notice: %1$s on WordPress %2$s with %3$s of %4$s was stopped because there are other WordPress records mapped to Salesforce %5$s of %6$s', 'object-sync-for-salesforce' ),
+						esc_html__( '%1$s: %2$s on WordPress %3$s with %4$s of %5$s was stopped because there are other WordPress records mapped to Salesforce %6$s of %7$s', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) ),
 						esc_attr( $op ),
 						esc_attr( $salesforce_mapping['wordpress_object'] ),
 						esc_attr( $wordpress_id_field_name ),

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -440,8 +440,9 @@ class Object_Sync_Sf_Salesforce_Push {
 			}
 
 			$title = sprintf(
-				// translators: placeholder is the name of the WordPress id field
-				esc_html__( 'Error: Salesforce Push: unable to process queue item because it has no WordPress %1$s.', 'object-sync-for-salesforce' ),
+				// translators: placeholders are: 1) the log status, 2) the name of the WordPress id field
+				esc_html__( '%1$s: Salesforce Push: unable to process queue item because it has no WordPress %2$s.', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $wordpress_id_field_name )
 			);
 
@@ -580,9 +581,11 @@ class Object_Sync_Sf_Salesforce_Push {
 					$this->schedule_name
 				);
 
-				$title = sprintf(
-					// translators: placeholders are: 1) the name of the WordPress object type, 2) the name of the WordPress ID field, 3) the value of the object's ID in WordPress, 4) the name of the Salesforce object
-					esc_html__( 'Success: Add to queue: Push WordPress %1$s with %2$s of %3$s to Salesforce %4$s.', 'object-sync-for-salesforce' ),
+				$log_status = 'success';
+				$title      = sprintf(
+					// translators: placeholders are: 1) the log status, 2) the name of the WordPress object type, 3) the name of the WordPress ID field, 4) the value of the object's ID in WordPress, 5) the name of the Salesforce object
+					esc_html__( '%1$s: Add to queue: Push WordPress %2$s with %3$s of %4$s to Salesforce %5$s.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $log_status ) ),
 					esc_attr( $mapping['wordpress_object'] ),
 					esc_attr( $wordpress_id_field_name ),
 					esc_attr( $object[ $wordpress_id_field_name ] ),
@@ -594,7 +597,7 @@ class Object_Sync_Sf_Salesforce_Push {
 					'message' => '',
 					'trigger' => $sf_sync_trigger,
 					'parent'  => esc_attr( $object[ $wordpress_id_field_name ] ),
-					'status'  => 'success',
+					'status'  => $log_status,
 				);
 				$results[] = $result;
 			} else {
@@ -703,8 +706,9 @@ class Object_Sync_Sf_Salesforce_Push {
 						}
 
 						$title = sprintf(
-							// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-							esc_html__( 'Error: %1$s Salesforce %2$s %3$s (WordPress %4$s with %5$s of %6$s)', 'object-sync-for-salesforce' ),
+							// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+							esc_html__( '%1$s: %2$s Salesforce %3$s %4$s (WordPress %5$s with %6$s of %7$s)', 'object-sync-for-salesforce' ),
+							ucfirst( esc_attr( $status ) ),
 							esc_attr( $op ),
 							esc_attr( $mapping['salesforce_object'] ),
 							esc_attr( $mapping_object['salesforce_id'] ),
@@ -738,8 +742,9 @@ class Object_Sync_Sf_Salesforce_Push {
 						}
 
 						$title = sprintf(
-							// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-							esc_html__( 'Success: %1$s Salesforce %2$s %3$s (WordPress %4$s with %5$s of %6$s)', 'object-sync-for-salesforce' ),
+							// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+							esc_html__( '%1$s: %2$s Salesforce %3$s %4$s (WordPress %5$s with %6$s of %7$s)', 'object-sync-for-salesforce' ),
+							ucfirst( esc_attr( $status ) ),
 							esc_attr( $op ),
 							esc_attr( $mapping['salesforce_object'] ),
 							esc_attr( $mapping_object['salesforce_id'] ),
@@ -780,8 +785,9 @@ class Object_Sync_Sf_Salesforce_Push {
 					}
 
 					$title = sprintf(
-						// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-						esc_html__( 'Notice: %1$s on Salesforce %2$s with Id of %3$s was stopped because there are other Salesforce records mapped to WordPress %4$s with %5$s of %6$s', 'object-sync-for-salesforce' ),
+						// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+						esc_html__( '%1$s: %2$s on Salesforce %3$s with Id of %4$s was stopped because there are other Salesforce records mapped to WordPress %5$s with %6$s of %7$s', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) ),
 						esc_attr( $op ),
 						esc_attr( $mapping['salesforce_object'] ),
 						esc_attr( $mapping_object['salesforce_id'] ),
@@ -974,8 +980,9 @@ class Object_Sync_Sf_Salesforce_Push {
 				}
 
 				$title = sprintf(
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value if there is one, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-					esc_html__( 'Error: %1$s Salesforce %2$s %3$s (WordPress %4$s with %5$s of %6$s)', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value if there is one, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+					esc_html__( '%1$s: %2$s Salesforce %3$s %4$s (WordPress %5$s with %6$s of %7$s)', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $op ),
 					esc_attr( $mapping['salesforce_object'] ),
 					isset( $salesforce_id ) ? ' ' . esc_attr( $salesforce_id ) : '',
@@ -1028,8 +1035,9 @@ class Object_Sync_Sf_Salesforce_Push {
 				}
 
 				$title = sprintf(
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-					esc_html__( 'Success: %1$s Salesforce %2$s %3$s (WordPress %4$s with %5$s of %6$s)', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status ,2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+					esc_html__( '%1$s: %2$s Salesforce %3$s %4$s (WordPress %5$s with %6$s of %7$s)', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $op ),
 					esc_attr( $mapping['salesforce_object'] ),
 					esc_attr( $salesforce_id ),
@@ -1087,11 +1095,21 @@ class Object_Sync_Sf_Salesforce_Push {
 				);
 
 				$body = sprintf(
-					// translators: placeholders are 1) the name of the Salesforce object type, 2) the error message returned from the Salesforce APIs
-					'<p>' . esc_html__( 'Object: %1$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: %2$s', 'object-sync-for-salesforce' ) . '</p>',
+					// translators: placeholders are 1) the name of the Salesforce object type, 2) the error message returned from the Salesforce APIs, 3) the parameters that were attempted
+					'<p>' . esc_html__( 'Object: %1$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: %2$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Params: %3$s', 'object-sync-for-salesforce' ) . '</p>',
 					esc_attr( $mapping['salesforce_object'] ),
-					esc_html( $api_result['data']['message'] )
+					esc_html( $api_result['data']['message'] ),
+					print_r( $params, true )
 				);
+
+				if ( isset( $upsert_key ) && isset( $upsert_value ) ) {
+					$body .= sprintf(
+						// translators: placeholders are 1) the upsert key attempted, 2) the upsert value attempted
+						'<p>' . esc_html__( 'Upsert key: %1$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Upsert value: %2$s', 'object-sync-for-salesforce' ) . '</p>',
+						esc_attr( $upsert_key ),
+						esc_attr( $upsert_value )
+					);
+				}
 
 				$result = array(
 					'title'   => $title,
@@ -1128,8 +1146,9 @@ class Object_Sync_Sf_Salesforce_Push {
 				}
 
 				$title = sprintf(
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the Salesforce Id value
-					esc_html__( 'Notice: %1$s: Did not sync WordPress %2$s with %3$s of %4$s with Salesforce Id %5$s because the last sync timestamp was greater than the object updated timestamp.', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the Salesforce Id value
+					esc_html__( '%1$s: %2$s: Did not sync WordPress %3$s with %4$s of %5$s with Salesforce Id %6$s because the last sync timestamp was greater than the object updated timestamp.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $op ),
 					esc_attr( $mapping['wordpress_object'] ),
 					esc_attr( $wordpress_id_field_name ),
@@ -1182,8 +1201,9 @@ class Object_Sync_Sf_Salesforce_Push {
 				}
 
 				$title = sprintf(
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-					esc_html__( 'Success: %1$s Salesforce %2$s %3$s (WordPress %4$s with %5$s of %6$s)', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+					esc_html__( '%1$s: %2$s Salesforce %3$s %4$s (WordPress %5$s with %6$s of %7$s)', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $op ),
 					esc_attr( $mapping['salesforce_object'] ),
 					esc_attr( $mapping_object['salesforce_id'] ),
@@ -1215,8 +1235,9 @@ class Object_Sync_Sf_Salesforce_Push {
 				}
 
 				$title = sprintf(
-					// translators: placeholders are: 1) what operation is happening, 2) the name of the Salesforce object, 3) the Salesforce Id value, 4) the name of the WordPress object type, 5) the WordPress id field name, 6) the WordPress object id value
-					esc_html__( 'Error: %1$s Salesforce %2$s %3$s (WordPress %4$s with %5$s of %6$s)', 'object-sync-for-salesforce' ),
+					// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object, 4) the Salesforce Id value, 5) the name of the WordPress object type, 6) the WordPress id field name, 7) the WordPress object id value
+					esc_html__( '%1$s: %2$s Salesforce %3$s %4$s (WordPress %5$s with %6$s of %7$s)', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
 					esc_attr( $op ),
 					esc_attr( $mapping['salesforce_object'] ),
 					esc_attr( $mapping_object['salesforce_id'] ),

--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -758,8 +758,10 @@ class Object_Sync_Sf_WordPress {
 
 		if ( isset( $result['errors'] ) && ! empty( $result['errors'] ) ) {
 			$status = 'error';
-			// translators: 1) is object type, 2) is id value
-			$title = sprintf( esc_html__( 'Error: WordPress update for %1$s ID %2$s was unsuccessful with these errors:', 'object-sync-for-salesforce' ),
+			$title  = sprintf(
+				// translators: 1) is log status, 2) is object type, 3) is id value
+				esc_html__( '%1$s: WordPress update for %2$s ID %3$s was unsuccessful with these errors:', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) ),
 				esc_attr( $name ),
 				esc_attr( $id )
 			);
@@ -1068,13 +1070,21 @@ class Object_Sync_Sf_WordPress {
 		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 		}
+
+		$status = 'error';
+		$title  = sprintf(
+			// translators: placeholders are: 1) the log status
+			esc_html__( '%1$s: Users: Tried to run user_upsert, and ended up without a user id', 'object-sync-for-salesforce' ),
+			ucfirst( esc_attr( $status ) )
+		);
+
 		$logging->setup(
 			// todo: can we get any more specific about this?
-			esc_html__( 'Error: Users: Tried to run user_upsert, and ended up without a user id', 'object-sync-for-salesforce' ),
+			$title,
 			'',
 			0,
 			0,
-			'error'
+			$status
 		);
 
 	}
@@ -1399,13 +1409,21 @@ class Object_Sync_Sf_WordPress {
 		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 		}
+
+		$status = 'error';
+		$title  = sprintf(
+			// translators: placeholders are: 1) the log status
+			esc_html__( '%1$s: Posts: Tried to run post_upsert, and ended up without a post id', 'object-sync-for-salesforce' ),
+			ucfirst( esc_attr( $status ) )
+		);
+
 		$logging->setup(
 			// todo: can we be more explicit here about what post upsert failed?
-			esc_html__( 'Error: Posts: Tried to run post_upsert, and ended up without a post id', 'object-sync-for-salesforce' ),
+			$title,
 			'',
 			0,
 			0,
-			'error'
+			$status
 		);
 
 	}
@@ -1706,14 +1724,21 @@ class Object_Sync_Sf_WordPress {
 		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 		}
+
+		$status = 'error';
+		$title  = sprintf(
+			// translators: placeholders are: 1) the log status
+			esc_html__( '%1$s: Attachments: Tried to run attachment_upsert, and ended up without an attachment id', 'object-sync-for-salesforce' ),
+			ucfirst( esc_attr( $status ) )
+		);
+
 		$logging->setup(
-			esc_html__( 'Error: Attachment: Tried to run attachment_upsert, and ended up without an attachment id', 'object-sync-for-salesforce' ),
+			$title,
 			'',
 			0,
 			0,
-			'error'
+			$status
 		);
-
 	}
 
 	/**
@@ -2025,12 +2050,20 @@ class Object_Sync_Sf_WordPress {
 		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 		}
+
+		$status = 'error';
+		$title  = sprintf(
+			// translators: placeholders are: 1) the log status
+			esc_html__( '%1$s: Terms: Tried to run term_upsert, and ended up without a term id', 'object-sync-for-salesforce' ),
+			ucfirst( esc_attr( $status ) )
+		);
+
 		$logging->setup(
-			esc_html__( 'Error: Terms: Tried to run term_upsert, and ended up without a term id', 'object-sync-for-salesforce' ),
+			$title,
 			'',
 			0,
 			0,
-			'error'
+			$status
 		);
 
 	}
@@ -2264,8 +2297,9 @@ class Object_Sync_Sf_WordPress {
 				}
 				$logging->setup(
 					sprintf(
-						// translators: %1$s is a number. %2$s is a key. %3$s is the value of that key. %4$s is a var_export'd array of comments.
-						esc_html__( 'Error: Comments: there are %1$s comment matches for the Salesforce key %2$s with the value of %3$s. Here they are: %4$s', 'object-sync-for-salesforce' ),
+						// translators: %1$s is the log status. %2$s is a number. %3$s is a key. %4$s is the value of that key. %5$s is a var_export'd array of comments.
+						esc_html__( '%1$s: Comments: there are %2$s comment matches for the Salesforce key %3$s with the value of %4$s. Here they are: %5$s', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) ),
 						absint( count( $comments ) ),
 						esc_html( $key ),
 						esc_html( $value ),
@@ -2346,12 +2380,20 @@ class Object_Sync_Sf_WordPress {
 		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 		}
+
+		$status = 'error';
+		$title  = sprintf(
+			// translators: placeholders are: 1) the log status
+			esc_html__( '%1$s: Comments: Tried to run comment_upsert, and ended up without a comment id', 'object-sync-for-salesforce' ),
+			ucfirst( esc_attr( $status ) )
+		);
+
 		$logging->setup(
-			esc_html__( 'Error: Comments: Tried to run comment_upsert, and ended up without a comment id', 'object-sync-for-salesforce' ),
+			$title,
 			'',
 			0,
 			0,
-			'error'
+			$status
 		);
 
 	}


### PR DESCRIPTION
## What does this PR do?

This edits the various log entries we create so they use the already existing status variable. It makes it easier to change, see what's going on, removes some unneeded duplication, etc.