### PR TITLE
Fix the object_sync_for_salesforce_pull_query_modify filter to prevent redundant elements

### DIFF
--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -745,6 +745,11 @@ class Object_Sync_Sf_Salesforce_Pull {
 		}
 		*/
 
+		// Make sure our SOQL object properties that are arrays are unique. This prevents values added via developer hook from being added repeatedly when a query is cached.
+		$soql->fields     = array_unique( $soql->fields, SORT_REGULAR );
+		$soql->order      = array_unique( $soql->order, SORT_REGULAR );
+		$soql->conditions = array_unique( $soql->conditions, SORT_REGULAR );
+
 		// serialize the currently running SOQL query and store it for this type
 		$serialized_current_query = maybe_serialize( $soql );
 		update_option( $this->option_prefix . 'currently_pulling_query_' . $type, $serialized_current_query, false );

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -737,9 +737,9 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		// quick example to change the order to descending
 		/*
-		add_filter( 'object_sync_for_salesforce_pull_query_modify', 'change_pull_query', 10, 6 );
+		add_filter( 'object_sync_for_salesforce_pull_query_modify', 'change_pull_query', 10, 4 );
 		// can always reduce this number if all the arguments are not necessary
-		function change_pull_query( $soql, $type, $salesforce_mapping, $mapped_fields, $salesforce_mapping, $mapped_fields ) {
+		function change_pull_query( $soql, $type, $salesforce_mapping, $mapped_fields ) {
 			$soql->order = 'DESC';
 			return $soql;
 		}

--- a/docs/extending-pull.md
+++ b/docs/extending-pull.md
@@ -7,10 +7,23 @@ When the plugin makes a call to the Salesforce API, it runs a SOQL query using a
 `object_sync_for_salesforce_pull_query_modify` allows you to change the SOQL query before it is sent to Salesforce.
 
 ```php
-// quick example to change the order to descending
-add_filter( 'object_sync_for_salesforce_pull_query_modify', 'change_pull_query', 10, 6 );
+/**
+// Example to change the order to descending
+*
+* @param object $soql
+*   The SOQL query object
+* @param string $object_type
+*   Salesforce object type
+* @param array $salesforce_mapping
+*   The map between the WordPress and Salesforce object types
+* @param array $mapped_fields
+*   The fields that are mapped between these objects
+* @return object $soql
+*   The SOQL query object
+*/
+add_filter( 'object_sync_for_salesforce_pull_query_modify', 'change_pull_query', 10, 4 );
 // can always reduce this number if all the arguments are not necessary
-function change_pull_query( $soql, $type, $salesforce_mapping, $mapped_fields, $salesforce_mapping, $mapped_fields ) {
+function change_pull_query( $soql, $type, $salesforce_mapping, $mapped_fields ) {
 	$soql->order = 'DESC';
 	return $soql;
 }


### PR DESCRIPTION
## What does this PR do?

Fix #314 by changing the `object_sync_for_salesforce_pull_query_modify` filter to:

1. Correct documentation and code comments that match what the filter is actually doing.
2. Ensure that the SOQL object properties which are arrays are always unique.
