### PR TITLE
If the WordPress field is wp_capabilities, we can treat it as WordPress expects it

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -808,8 +808,8 @@ class Object_Sync_Sf_Mapping {
 
 				// Is the field in WordPress an array, if we unserialize it? Salesforce wants it to be an imploded string.
 				if ( is_array( maybe_unserialize( $object[ $wordpress_field ] ) ) ) {
-					// the members plugin does a unique thing with the array of capabilities. the keys of the array are the role names, so we need to send those to Salesforce.
-					if ( function_exists( 'members_plugin' ) && 'wp_capabilities' === $wordpress_field ) {
+					// if the WordPress field is a list of capabilities (the source field is wp_capabilities), we need to get the array keys from WordPress to send them to Salesforce.
+					if ( 'wp_capabilities' === $wordpress_field ) {
 						$object[ $wordpress_field ] = implode( $this->array_delimiter, array_keys( $object[ $wordpress_field ] ) );
 					} else {
 						$object[ $wordpress_field ] = implode( $this->array_delimiter, $object[ $wordpress_field ] );
@@ -899,8 +899,8 @@ class Object_Sync_Sf_Mapping {
 					// destination field in WordPress accepts multiple values, explode the string into an array and then serialize it.
 					if ( in_array( $salesforce_field_type, $this->array_types_from_salesforce ) ) {
 						$object[ $salesforce_field ] = explode( $this->array_delimiter, $object[ $salesforce_field ] );
-						// the members plugin does a unique thing with the array of capabilities. the keys of the array are the role names, so we need to only save those as array items in WordPress.
-						if ( function_exists( 'members_plugin' ) && 'wp_capabilities' === $wordpress_field ) {
+						// if the WordPress field is a list of capabilities (the destination field is wp_capabilities), we need to set the array for WordPress to save it.
+						if ( 'wp_capabilities' === $wordpress_field ) {
 							$capabilities = array();
 							foreach ( $object[ $salesforce_field ] as $capability ) {
 								$capabilities[ $capability ] = true;

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -808,7 +808,12 @@ class Object_Sync_Sf_Mapping {
 
 				// Is the field in WordPress an array, if we unserialize it? Salesforce wants it to be an imploded string.
 				if ( is_array( maybe_unserialize( $object[ $wordpress_field ] ) ) ) {
-					$object[ $wordpress_field ] = implode( $this->array_delimiter, $object[ $wordpress_field ] );
+					// the members plugin does a unique thing with the array of capabilities. the keys of the array are the role names, so we need to send those to Salesforce.
+					if ( function_exists( 'members_plugin' ) && 'wp_capabilities' === $wordpress_field ) {
+						$object[ $wordpress_field ] = implode( $this->array_delimiter, array_keys( $object[ $wordpress_field ] ) );
+					} else {
+						$object[ $wordpress_field ] = implode( $this->array_delimiter, $object[ $wordpress_field ] );
+					}
 				}
 
 				if ( isset( $salesforce_field_type ) ) {
@@ -894,6 +899,14 @@ class Object_Sync_Sf_Mapping {
 					// destination field in WordPress accepts multiple values, explode the string into an array and then serialize it.
 					if ( in_array( $salesforce_field_type, $this->array_types_from_salesforce ) ) {
 						$object[ $salesforce_field ] = explode( $this->array_delimiter, $object[ $salesforce_field ] );
+						// the members plugin does a unique thing with the array of capabilities. the keys of the array are the role names, so we need to only save those as array items in WordPress.
+						if ( function_exists( 'members_plugin' ) && 'wp_capabilities' === $wordpress_field ) {
+							$capabilities = array();
+							foreach ( $object[ $salesforce_field ] as $capability ) {
+								$capabilities[ $capability ] = true;
+							}
+							$object[ $salesforce_field ] = $capabilities;
+						}
 					}
 
 					// Handle specific data types from Salesforce.


### PR DESCRIPTION
## What does this PR do?

As indicated in #320, WordPress stores capabilities in a certain way, and this doesn't match how Salesforce stores picklist values. I think this PR translates for that field's usage, both coming from and going to Salesforce.

## How do I test this PR?

- Install any plugin that supports the WP roles API (members plugin, multiple-roles plugin, etc.)
- Map users to something in Salesforce
- Give users multiple roles in WordPress
- Give users multiple roles in Salesforce