### PR TITLE
Hide admin menu items before authorizing with Salesforce

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -2219,8 +2219,17 @@ class Object_Sync_Sf_Admin {
 		echo '<h2 class="nav-tab-wrapper">';
 		foreach ( $tabs as $tab_key => $tab_caption ) {
 			$active = $current_tab === $tab_key ? ' nav-tab-active' : '';
-			if ( 'settings' === $tab_key || ( isset( $consumer_key ) && isset( $consumer_secret ) && ! empty( $consumer_key ) && ! empty( $consumer_secret ) ) ) {
-				echo sprintf( '<a class="nav-tab%1$s" href="%2$s">%3$s</a>',
+
+			if ( true === $this->salesforce['is_authorized'] ) {
+				echo sprintf(
+					'<a class="nav-tab%1$s" href="%2$s">%3$s</a>',
+					esc_attr( $active ),
+					esc_url( '?page=object-sync-salesforce-admin&tab=' . $tab_key ),
+					esc_html( $tab_caption )
+				);
+			} elseif ( 'settings' === $tab_key || ( 'authorize' === $tab_key && isset( $consumer_key ) && isset( $consumer_secret ) && ! empty( $consumer_key ) && ! empty( $consumer_secret ) ) ) {
+				echo sprintf(
+					'<a class="nav-tab%1$s" href="%2$s">%3$s</a>',
 					esc_attr( $active ),
 					esc_url( '?page=object-sync-salesforce-admin&tab=' . $tab_key ),
 					esc_html( $tab_caption )

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -496,12 +496,14 @@ class Object_Sync_Sf_Admin {
 					break;
 			} // End switch().
 		} catch ( SalesforceApiException $ex ) {
-			echo sprintf( '<p>Error <strong>%1$s</strong>: %2$s</p>',
+			echo sprintf(
+				'<p>Error <strong>%1$s</strong>: %2$s</p>',
 				absint( $ex->getCode() ),
 				esc_html( $ex->getMessage() )
 			);
 		} catch ( Exception $ex ) {
-			echo sprintf( '<p>Error <strong>%1$s</strong>: %2$s</p>',
+			echo sprintf(
+				'<p>Error <strong>%1$s</strong>: %2$s</p>',
 				absint( $ex->getCode() ),
 				esc_html( $ex->getMessage() )
 			);
@@ -581,8 +583,9 @@ class Object_Sync_Sf_Admin {
 				'args'     => array(
 					'type'     => 'url',
 					'validate' => 'sanitize_validate_text',
-					// translators: %1$s is the admin URL for the Authorize tab
-					'desc'     => sprintf( __( 'In most cases, you will want to use %1$s for this value.', 'object-sync-for-salesforce' ),
+					'desc'     => sprintf(
+						// translators: %1$s is the admin URL for the Authorize tab
+						__( 'In most cases, you will want to use %1$s for this value.', 'object-sync-for-salesforce' ),
 						get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=authorize' )
 					),
 					'constant' => 'OBJECT_SYNC_SF_SALESFORCE_CALLBACK_URL',
@@ -596,8 +599,9 @@ class Object_Sync_Sf_Admin {
 				'args'     => array(
 					'type'     => 'url',
 					'validate' => 'sanitize_validate_text',
-					// translators: 1) production salesforce login, 2) sandbox salesforce login
-					'desc'     => sprintf( __( 'For most Salesforce setups, you should use %1$s for production and %2$s for sandbox. If you try to use an instance name as the URL, you may encounter Salesforce errors.', 'object-sync-for-salesforce' ),
+					'desc'     => sprintf(
+						// translators: 1) production salesforce login, 2) sandbox salesforce login
+						__( 'For most Salesforce setups, you should use %1$s for production and %2$s for sandbox. If you try to use an instance name as the URL, you may encounter Salesforce errors.', 'object-sync-for-salesforce' ),
 						esc_url( 'https://login.salesforce.com' ),
 						esc_url( 'https://test.salesforce.com' )
 					),
@@ -1805,7 +1809,8 @@ class Object_Sync_Sf_Admin {
 				$value = $args['default'];
 			}
 
-			echo sprintf( '<input type="%1$s" value="%2$s" name="%3$s" id="%4$s" class="%5$s"%6$s>',
+			echo sprintf(
+				'<input type="%1$s" value="%2$s" name="%3$s" id="%4$s" class="%5$s"%6$s>',
 				esc_attr( $type ),
 				esc_attr( $value ),
 				esc_attr( $name ),
@@ -1814,12 +1819,14 @@ class Object_Sync_Sf_Admin {
 				esc_html( $checked )
 			);
 			if ( '' !== $desc ) {
-				echo sprintf( '<p class="description">%1$s</p>',
+				echo sprintf(
+					'<p class="description">%1$s</p>',
 					esc_html( $desc )
 				);
 			}
 		} else {
-			echo sprintf( '<p><code>%1$s</code></p>',
+			echo sprintf(
+				'<p><code>%1$s</code></p>',
 				esc_html__( 'Defined in wp-config.php', 'object-sync-for-salesforce' )
 			);
 		}
@@ -1847,7 +1854,8 @@ class Object_Sync_Sf_Admin {
 					$checked = 'checked';
 				}
 			}
-			echo sprintf( '<div class="checkbox"><label><input type="%1$s" value="%2$s" name="%3$s[]" id="%4$s"%5$s>%6$s</label></div>',
+			echo sprintf(
+				'<div class="checkbox"><label><input type="%1$s" value="%2$s" name="%3$s[]" id="%4$s"%5$s>%6$s</label></div>',
 				esc_attr( $type ),
 				esc_attr( $key ),
 				esc_attr( $name ),
@@ -1856,7 +1864,8 @@ class Object_Sync_Sf_Admin {
 				esc_html( $text )
 			);
 			if ( '' !== $desc ) {
-				echo sprintf( '<p class="description">%1$s</p>',
+				echo sprintf(
+					'<p class="description">%1$s</p>',
 					esc_html( $desc )
 				);
 			}
@@ -1876,7 +1885,8 @@ class Object_Sync_Sf_Admin {
 		if ( ! isset( $args['constant'] ) || ! defined( $args['constant'] ) ) {
 			$current_value = get_option( $name );
 
-			echo sprintf( '<div class="select"><select id="%1$s" name="%2$s"><option value="">- ' . __( 'Select one', 'object-sync-for-salesforce' ) . ' -</option>',
+			echo sprintf(
+				'<div class="select"><select id="%1$s" name="%2$s"><option value="">- ' . __( 'Select one', 'object-sync-for-salesforce' ) . ' -</option>',
 				esc_attr( $id ),
 				esc_attr( $name )
 			);
@@ -1889,7 +1899,8 @@ class Object_Sync_Sf_Admin {
 					$selected = ' selected';
 				}
 
-				echo sprintf( '<option value="%1$s"%2$s>%3$s</option>',
+				echo sprintf(
+					'<option value="%1$s"%2$s>%3$s</option>',
 					esc_attr( $value ),
 					esc_attr( $selected ),
 					esc_html( $text )
@@ -1898,13 +1909,15 @@ class Object_Sync_Sf_Admin {
 			}
 			echo '</select>';
 			if ( '' !== $desc ) {
-				echo sprintf( '<p class="description">%1$s</p>',
+				echo sprintf(
+					'<p class="description">%1$s</p>',
 					esc_html( $desc )
 				);
 			}
 			echo '</div>';
 		} else {
-			echo sprintf( '<p><code>%1$s</code></p>',
+			echo sprintf(
+				'<p><code>%1$s</code></p>',
 				esc_html__( 'Defined in wp-config.php', 'object-sync-for-salesforce' )
 			);
 		}
@@ -1940,20 +1953,23 @@ class Object_Sync_Sf_Admin {
 		$desc  = $args['desc'];
 		$url   = $args['url'];
 		if ( isset( $args['link_class'] ) ) {
-			echo sprintf( '<p><a class="%1$s" href="%2$s">%3$s</a></p>',
+			echo sprintf(
+				'<p><a class="%1$s" href="%2$s">%3$s</a></p>',
 				esc_attr( $args['link_class'] ),
 				esc_url( $url ),
 				esc_html( $label )
 			);
 		} else {
-			echo sprintf( '<p><a href="%1$s">%2$s</a></p>',
+			echo sprintf(
+				'<p><a href="%1$s">%2$s</a></p>',
 				esc_url( $url ),
 				esc_html( $label )
 			);
 		}
 
 		if ( '' !== $desc ) {
-			echo sprintf( '<p class="description">%1$s</p>',
+			echo sprintf(
+				'<p class="description">%1$s</p>',
 				esc_html( $desc )
 			);
 		}
@@ -2000,8 +2016,9 @@ class Object_Sync_Sf_Admin {
 			$versions_from_cache = esc_html__( 'items were not loaded from the cache', 'object-sync-salesforce' );
 		}
 
-		// translators: 1) $versions_is_cached is the "This list is/is not cached, and/but" line, 2) $versions_from_cache is the "items were/were not loaded from the cache" line
-		$versions_apicall_summary = sprintf( esc_html__( 'Available Salesforce API versions. %1$s %2$s. This is not an authenticated request, so it does not touch the Salesforce token.', 'object-sync-for-salesforce' ),
+		$versions_apicall_summary = sprintf(
+			// translators: 1) $versions_is_cached is the "This list is/is not cached, and/but" line, 2) $versions_from_cache is the "items were/were not loaded from the cache" line
+			esc_html__( 'Available Salesforce API versions. %1$s %2$s. This is not an authenticated request, so it does not touch the Salesforce token.', 'object-sync-for-salesforce' ),
 			$versions_is_cached,
 			$versions_from_cache
 		);
@@ -2055,7 +2072,8 @@ class Object_Sync_Sf_Admin {
 		$this->access_token  = delete_option( $this->option_prefix . 'access_token' );
 		$this->instance_url  = delete_option( $this->option_prefix . 'instance_url' );
 		$this->refresh_token = delete_option( $this->option_prefix . 'refresh_token' );
-		echo sprintf( '<p>You have been logged out. You can use the <a href="%1$s">%2$s</a> tab to log in again.</p>',
+		echo sprintf(
+			'<p>You have been logged out. You can use the <a href="%1$s">%2$s</a> tab to log in again.</p>',
 			esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=authorize' ) ),
 			esc_html__( 'Authorize', 'object-sync-for-salesforce' )
 		);
@@ -2240,20 +2258,24 @@ class Object_Sync_Sf_Admin {
 	*/
 	private function get_schedule_count( $schedule_name = '' ) {
 		if ( '' !== $schedule_name ) {
-			$count       = count( $this->queue->search(
-				array(
-					'group'  => $schedule_name,
-					'status' => ActionScheduler_Store::STATUS_PENDING,
-				),
-				'ARRAY_A'
-			) );
-			$group_count = count( $this->queue->search(
-				array(
-					'group'  => $schedule_name . $this->action_group_suffix,
-					'status' => ActionScheduler_Store::STATUS_PENDING,
-				),
-				'ARRAY_A'
-			) );
+			$count       = count(
+				$this->queue->search(
+					array(
+						'group'  => $schedule_name,
+						'status' => ActionScheduler_Store::STATUS_PENDING,
+					),
+					'ARRAY_A'
+				)
+			);
+			$group_count = count(
+				$this->queue->search(
+					array(
+						'group'  => $schedule_name . $this->action_group_suffix,
+						'status' => ActionScheduler_Store::STATUS_PENDING,
+					),
+					'ARRAY_A'
+				)
+			);
 			return $count + $group_count;
 		} else {
 			return 0;


### PR DESCRIPTION
## What does this PR do?

This closes #325. It hides all menu items except Settings and Authorize if the user has not authorized with Salesforce.

Here's how the menu visibility works:

1. If user has not filled in the credentials, only show Settings.
2. If user has filled in credentials but has not authorized the app in Salesforce, only show Settings and Authorize.
3. If they've actually authorized with Salesforce, show all the available items.

## How do I test this PR?

- install the plugin
- fill in the credentials but don't authorize
- authorize