### PR TITLE
343 deleting fields fix

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1548,6 +1548,10 @@ class Object_Sync_Sf_Admin {
 					$url = esc_url_raw( $post_data['redirect_url_error'] ) . '&transient=' . $cachekey;
 				}
 			} else {
+				// if the user has saved a fieldmap, clear the currently running query value if there is one
+				if ( '' !== get_option( $this->option_prefix . 'currently_pulling_query_' . $post_data['salesforce_object'], '' ) ) {
+					$this->pull->clear_current_type_query( $post_data['salesforce_object'] );
+				}
 				if ( isset( $post_data['transient'] ) ) { // there was previously an error saved. can delete it now.
 					$this->sfwp_transients->delete( esc_attr( $post_data['map_transient'] ) );
 				}

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -493,7 +493,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					// translators: placeholders are: 1) the log status, 2) the server error code, and 3) the name of the Salesforce object
 					esc_html__( '%1$s: %2$s when pulling %3$s data from Salesforce', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
-					absint( $response['errorCode'] ),
+					esc_attr( $response['errorCode'] ),
 					esc_attr( $salesforce_mapping['salesforce_object'] )
 				);
 

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -492,17 +492,17 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$status    = 'error';
 				$log_title = sprintf(
 					// translators: placeholders are: 1) the log status, 2) the server error code, and 3) the name of the Salesforce object
-					esc_html__( '%1$s: %2$s when pulling %3$s data from Salesforce.', 'object-sync-for-salesforce' ),
+					esc_html__( '%1$s: %2$s when pulling %3$s data from Salesforce. Check and resave the fieldmap.', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
 					esc_attr( $response['errorCode'] ),
 					esc_attr( $salesforce_mapping['salesforce_object'] )
 				);
-				$log_body = '<p>' . esc_html__( 'A field may have been deleted from Salesforce, or it has otherwise become invalid.', 'object-sync-for-salesforce' ) . '</p>';
+				$log_body = '<p>' . esc_html__( 'A field may have been deleted from Salesforce, or it has otherwise become invalid. You may need to check and resave your fieldmap.', 'object-sync-for-salesforce' ) . '</p>';
 
 				// if it's an invalid field, try to clear the cached query so it can try again next time
 				if ( '' !== get_option( $this->option_prefix . 'currently_pulling_query_' . $type, '' ) ) {
 					$this->clear_current_type_query( $type );
-					$log_title .= esc_html__( ' Stored query cleared.', 'object-sync-for-salesforce' );
+					$log_title .= esc_html__( ' The stored query has been cleared.', 'object-sync-for-salesforce' );
 					$log_body  .= '<p>' . esc_html__( 'The currently stored query for this object type has been deleted.', 'object-sync-for-salesforce' ) . '</p>';
 				}
 

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -2211,7 +2211,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 	*   e.g. "Contact", "Account", etc.
 	*
 	*/
-	private function clear_current_type_query( $type ) {
+	public function clear_current_type_query( $type ) {
 		// update the last sync timestamp for this content type
 		$this->increment_current_type_datetime( $type );
 		// delete the option value for the currently pulling query for this type

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -487,6 +487,16 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$this->clear_current_type_query( $type );
 				}
 			} elseif ( isset( $response['errorCode'] ) ) {
+
+				// catch specific error codes from Salesforce when possible
+
+				// if it's an invalid field, try to clear the cached query so it can try again next time
+				if ( 'INVALID_FIELD' === $response['errorCode'] ) {
+					if ( '' !== get_option( $this->option_prefix . 'currently_pulling_query_' . $type, '' ) ) {
+						$this->clear_current_type_query( $type );
+					}
+				}
+
 				// create log entry for failed pull
 				$status = 'error';
 				$title  = sprintf(


### PR DESCRIPTION
## What does this PR do?

This fixes #344 by:

1. Checking for an `INVALID_FIELD` response from the Salesforce API. If it gets one, it will clear the saved query and make a specific error log.
2. If a user saves their fieldmap, it will also clear the saved query, in the assumption that the fields being mapped may have changed.

## How do I test this PR?

- create a working fieldmap
- delete a field in Salesforce
- see that the current running query is cleared the next time it runs
- save the fieldmap settings in the admin
- see that the current running query is cleared immediately
