### PR TITLE
For WordPress 5.3 compatibility, replace `current_time( 'timestamp' )` with `time()`

### DIFF
--- a/classes/activate.php
+++ b/classes/activate.php
@@ -146,7 +146,7 @@ class Object_Sync_Sf_Activate {
 		}
 
 		// store right now as the time for the plugin's activation
-		update_option( $this->option_prefix . 'activate_time', current_time( 'timestamp', true ) );
+		update_option( $this->option_prefix . 'activate_time', time() );
 
 		// utf8mb4 conversion.
 		maybe_convert_table_to_utf8mb4( $field_map_table );
@@ -244,7 +244,7 @@ class Object_Sync_Sf_Activate {
 				}
 				// create new recurring task for action-scheduler to check for data to pull from Salesforce
 				$this->queue->schedule_recurring(
-					current_time( 'timestamp', true ), // plugin seems to expect UTC
+					time(), // plugin seems to expect UTC
 					$this->queue->get_frequency( $schedule_name, 'seconds' ),
 					$this->schedulable_classes[ $schedule_name ]['initializer'],
 					array(),

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -291,7 +291,7 @@ class Object_Sync_Sf_Admin {
 
 		// create new recurring task for action-scheduler to check for data to pull from salesforce
 		$this->queue->schedule_recurring(
-			current_time( 'timestamp', true ), // plugin seems to expect UTC
+			time(), // plugin seems to expect UTC
 			$this->queue->get_frequency( $schedule_name, 'seconds' ),
 			$this->schedulable_classes[ $schedule_name ]['initializer'],
 			array(),

--- a/classes/salesforce_pull.php
+++ b/classes/salesforce_pull.php
@@ -175,7 +175,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$this->get_deleted_records();
 
 			// Store this request time for the throttle check.
-			update_option( $this->option_prefix . 'pull_last_sync', current_time( 'timestamp', true ) );
+			update_option( $this->option_prefix . 'pull_last_sync', time() );
 			return true;
 
 		} else {
@@ -196,7 +196,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		$pull_throttle = get_option( $this->option_prefix . 'pull_throttle', 5 );
 		$last_sync     = get_option( $this->option_prefix . 'pull_last_sync', 0 );
 
-		if ( current_time( 'timestamp', true ) > ( $last_sync + $pull_throttle ) ) {
+		if ( time() > ( $last_sync + $pull_throttle ) ) {
 			return true;
 		} else {
 			return false;
@@ -880,13 +880,13 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			// Iterate over each field mapping to determine our query parameters.
 			foreach ( $mappings as $salesforce_mapping ) {
-				$last_merge_sync = get_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], current_time( 'timestamp', true ) );
-				$now             = current_time( 'timestamp', true );
+				$last_merge_sync = get_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], time() );
+				$now             = time();
 				update_option( $this->option_prefix . 'pull_merge_last_' . $salesforce_mapping['salesforce_object'], $now );
 
 				// get_deleted() constraint: startDate cannot be more than 30 days ago
 				// (using an incompatible date may lead to exceptions).
-				$last_merge_sync = $last_merge_sync > ( current_time( 'timestamp', true ) - 2505600 ) ? $last_merge_sync : ( current_time( 'timestamp', true ) - 2505600 );
+				$last_merge_sync = $last_merge_sync > ( time() - 2505600 ) ? $last_merge_sync : ( time() - 2505600 );
 
 				// get_deleted() constraint: startDate must be at least one minute greater
 				// than endDate.
@@ -1020,13 +1020,13 @@ class Object_Sync_Sf_Salesforce_Pull {
 			// Iterate over each field mapping to determine our query parameters.
 			foreach ( $mappings as $salesforce_mapping ) {
 
-				$last_delete_sync = get_option( $this->option_prefix . 'pull_delete_last_' . $type, current_time( 'timestamp', true ) );
-				$now              = current_time( 'timestamp', true );
+				$last_delete_sync = get_option( $this->option_prefix . 'pull_delete_last_' . $type, time() );
+				$now              = time();
 				update_option( $this->option_prefix . 'pull_delete_last_' . $type, $now );
 
 				// get_deleted() constraint: startDate cannot be more than 30 days ago
 				// (using an incompatible date may lead to exceptions).
-				$last_delete_sync = $last_delete_sync > ( current_time( 'timestamp', true ) - 2505600 ) ? $last_delete_sync : ( current_time( 'timestamp', true ) - 2505600 );
+				$last_delete_sync = $last_delete_sync > ( time() - 2505600 ) ? $last_delete_sync : ( time() - 2505600 );
 
 				// get_deleted() constraint: startDate must be at least one minute greater
 				// than endDate.
@@ -1118,7 +1118,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 				}
 
-				update_option( $this->option_prefix . 'pull_delete_last_' . $type, current_time( 'timestamp', true ) );
+				update_option( $this->option_prefix . 'pull_delete_last_' . $type, time() );
 
 			} // End foreach().
 		} // End foreach().
@@ -1248,8 +1248,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		foreach ( $salesforce_mappings as $salesforce_mapping ) {
 
-			// this returns the row that maps the individual Salesforce row to the individual WordPress row
-			// todo: this is where we'd start to address issue #135. we'd have to loop through mapping_objects if any existed.
+			// this returns the row that maps an individual Salesforce row to an individual WordPress row
 			if ( isset( $object['Id'] ) ) {
 				$mapping_objects = $this->mappings->load_all_by_salesforce( $object['Id'] );
 			} else {
@@ -2232,7 +2231,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 	private function increment_current_type_datetime( $type, $next_query_modified_date = '' ) {
 		// update the last sync timestamp for this content type
 		if ( '' === $next_query_modified_date ) {
-			$next_query_modified_date = current_time( 'timestamp', true );
+			$next_query_modified_date = time();
 		} else {
 			$next_query_modified_date = strtotime( $next_query_modified_date );
 		}


### PR DESCRIPTION
## What does this PR do?

In WordPress 5.3, `current_time( `timestamp' )` is no longer recommended. Rather, they say we should use `time()` to get timestamps. This PR fixes #342.

## How do I test this PR?

### Existing plugin setup

- [x] make sure the pull from Salesforce schedule runs when it's supposed to
- [x] make sure pulling data populates and processes the queue correctly
- [x] make sure pushing data populates and processes the queue correctly
- [x] make sure log pruning works as often as it's supposed to
- [x] make sure pulling data correctly prevents an immediate push/infinite loop

### New plugin setup

- [x] do a clean activation of the plugin to make sure the database settings are filled correctly
- [x] make sure the pull from Salesforce schedule runs when it's supposed to
- [x] make sure pulling data populates and processes the queue correctly
- [x] make sure pushing data populates and processes the queue correctly
- [x] make sure log pruning works as often as it's supposed to
- [x] make sure pulling data correctly prevents an immediate push/infinite loop
