### PR TITLE
Check for a WordPress ID before creating an object map.

### DIFF
--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -631,48 +631,39 @@ class Object_Sync_Sf_Mapping {
 		// temporary variable to allow us to check the data to make sure it isn't missing anything it needs.
 		$data['status'] = 'ready';
 
-		if ( ! isset( $data['wordpress_id'] ) ) {
-			$status = 'error';
+		if ( ! isset( $data['wordpress_id'] ) || substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' ) {
+			$status         = 'error';
+			$data['status'] = $status; // error
 			if ( isset( $this->logging ) ) {
 				$logging = $this->logging;
 			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
 				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 			}
-			$logging->setup(
-				sprintf(
+			if ( ! isset( $data['wordpress_id'] ) ) {
+				$log_title = sprintf(
 					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of the Salesforce object.
 					esc_html__( '%1$s Mapping: caused by trying to map the WordPress %2$s with no ID value to Salesforce ID %3$s. It may have been deleted.', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
 					esc_attr( $data['wordpress_object'] ),
 					esc_attr( $data['salesforce_id'] )
-				),
-				'',
-				0,
-				0,
-				$status
-			);
-			$data['status'] = $status; // error
-		} elseif ( substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' ) {
-			$status = 'error';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-			$logging->setup(
-				sprintf(
+				);
+				
+			} elseif ( substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' ) {
+				$log_title = sprintf(
 					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
 					esc_html__( '%1$s Mapping: caused by trying to map the WordPress %2$s with ID of %3$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
 					esc_attr( $data['wordpress_object'] ),
 					absint( $data['wordpress_id'] )
-				),
+				);
+			}
+			$logging->setup(
+				$log_title,
 				'',
 				0,
 				0,
 				$status
 			);
-			$data['status'] = $status; // error
 		}
 		return $data;
 	}

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -434,28 +434,10 @@ class Object_Sync_Sf_Mapping {
 		$data['created'] = current_time( 'mysql' );
 		// Check to see if we don't know the salesforce id and it is not a temporary id, or if this is pending.
 		// If it is using a temporary id, the map will get updated after it finishes running; it won't call this method unless there's an error, which we should log.
-		if ( isset( $data['wordpress_id'] ) && ( substr( $data['salesforce_id'], 0, 7 ) !== 'tmp_sf_' || ( isset( $data['action'] ) && 'pending' === $data['action'] ) ) ) {
+		if ( substr( $data['salesforce_id'], 0, 7 ) !== 'tmp_sf_' || ( isset( $data['action'] ) && 'pending' === $data['action'] ) ) {
 			unset( $data['action'] );
 			$insert = $this->wpdb->insert( $this->object_map_table, $data );
 		} else {
-			// if there's a temporary Salesforce ID and this isn't pending, it's an error
-			if ( ( substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' && 'pending' !== $data['action'] ) ) {
-				$log_title = sprintf(
-					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
-					esc_html__( '%1$s Mapping: caused by trying to map the WordPress %2$s with ID of %3$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
-					ucfirst( esc_attr( $status ) ),
-					esc_attr( $data['wordpress_object'] ),
-					absint( $data['wordpress_id'] )
-				);
-			} elseif ( ! isset( $data['wordpress_id'] ) ) {
-				$log_title = sprintf(
-					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
-					esc_html__( '%1$s Mapping: caused by trying to map the Salesforce ID %2$s to a WordPress %3$s with no ID. It may have been deleted.', 'object-sync-for-salesforce' ),
-					ucfirst( esc_attr( $status ) ),
-					esc_attr( $data['salesforce_id'] ),
-					esc_attr( $data['wordpress_object'] )
-				);
-			}
 			$status = 'error';
 			if ( isset( $this->logging ) ) {
 				$logging = $this->logging;
@@ -463,7 +445,13 @@ class Object_Sync_Sf_Mapping {
 				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 			}
 			$logging->setup(
-				$log_title,
+				sprintf(
+					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
+					esc_html__( '%1$s Mapping: error caused by trying to map the WordPress %2$s with ID of %3$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
+					esc_attr( $data['wordpress_object'] ),
+					absint( $data['wordpress_id'] )
+				),
 				'',
 				0,
 				0,

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -432,20 +432,30 @@ class Object_Sync_Sf_Mapping {
 	public function create_object_map( $posted = array() ) {
 		$data            = $this->setup_object_map_data( $posted );
 		$data['created'] = current_time( 'mysql' );
-
-		// Check the temporary $data['status'] value. if there's an error, we should log it in setup_object_map_data.
-		if ( 'ready' !== $data['status'] ) {
-			return false;
-		} else {
-			unset( $data['status'] );
-		}
-
-		// Check to see if this is pending a Salesforce Id.
-		// If it is using a temporary Id, the map will get updated after it finishes running; it won't call this method unless there's an error, which we should log.
-		if ( isset( $data['action'] ) && 'pending' === $data['action'] ) {
+		// Check to see if we don't know the salesforce id and it is not a temporary id, or if this is pending.
+		// If it is using a temporary id, the map will get updated after it finishes running; it won't call this method unless there's an error, which we should log.
+		if ( isset( $data['wordpress_id'] ) && ( substr( $data['salesforce_id'], 0, 7 ) !== 'tmp_sf_' || ( isset( $data['action'] ) && 'pending' === $data['action'] ) ) ) {
 			unset( $data['action'] );
 			$insert = $this->wpdb->insert( $this->object_map_table, $data );
 		} else {
+			// if there's a temporary Salesforce ID and this isn't pending, it's an error
+			if ( ( substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' && 'pending' !== $data['action'] ) ) {
+				$log_title = sprintf(
+					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
+					esc_html__( '%1$s Mapping: caused by trying to map the WordPress %2$s with ID of %3$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
+					esc_attr( $data['wordpress_object'] ),
+					absint( $data['wordpress_id'] )
+				);
+			} elseif ( ! isset( $data['wordpress_id'] ) ) {
+				$log_title = sprintf(
+					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
+					esc_html__( '%1$s Mapping: caused by trying to map the Salesforce ID %2$s to a WordPress %3$s with no ID. It may have been deleted.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) ),
+					esc_attr( $data['salesforce_id'] ),
+					esc_attr( $data['wordpress_object'] )
+				);
+			}
 			$status = 'error';
 			if ( isset( $this->logging ) ) {
 				$logging = $this->logging;
@@ -453,14 +463,7 @@ class Object_Sync_Sf_Mapping {
 				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
 			}
 			$logging->setup(
-				sprintf(
-					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object, 4) is the action parameter value
-					esc_html__( '%1$s Mapping: caused by trying to map the WordPress %2$s with ID of %3$s with an incorrect action parameter, %4$s.', 'object-sync-for-salesforce' ),
-					ucfirst( esc_attr( $status ) ),
-					esc_attr( $data['wordpress_object'] ),
-					absint( $data['wordpress_id'] ),
-					isset( $data['action'] ) ? esc_attr( $data['action'] ) : ''
-				),
+				$log_title,
 				'',
 				0,
 				0,
@@ -591,14 +594,6 @@ class Object_Sync_Sf_Mapping {
 	 */
 	public function update_object_map( $posted = array(), $id = '' ) {
 		$data = $this->setup_object_map_data( $posted );
-
-		// Check the temporary $data['status'] value. if there's an error, we should have already logged it in setup_object_map_data.
-		if ( 'ready' !== $data['status'] ) {
-			return false;
-		} else {
-			unset( $data['status'] );
-		}
-
 		if ( ! isset( $data['object_updated'] ) ) {
 			$data['object_updated'] = current_time( 'mysql' );
 		}
@@ -625,57 +620,9 @@ class Object_Sync_Sf_Mapping {
 	private function setup_object_map_data( $posted = array() ) {
 		$allowed_fields   = $this->wpdb->get_col( "DESC {$this->object_map_table}", 0 );
 		$allowed_fields[] = 'action'; // we use this in both directions even though it isn't in the database; we remove it from the array later if it is present
-		$data             = array_intersect_key( $posted, array_flip( $allowed_fields ) );
-		// temporary variable to allow us to check the data to make sure it isn't missing anything it needs.
-		$data['status'] = 'ready';
-		if ( ! isset( $data['wordpress_id'] ) || substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' ) {
-			$data['status'] = 'error'; // error
-			if ( ! isset( $data['wordpress_id'] ) ) {
-				$finish = sprintf(
-					// translators: %1$s is the Id of the Salesforce object.
-					esc_html__( 'The Salesforce ID is %1$s. The WordPress ID does not exist. It may have been deleted.', 'object-sync-for-salesforce' ),
-					esc_attr( $data['salesforce_id'] )
-				);
-			} elseif ( substr( $data['salesforce_id'], 0, 7 ) === 'tmp_sf_' ) {
-				$finish = sprintf(
-					// translators: %1$s is the Id of the Salesforce object.
-					esc_html__( 'The WordPress ID is %1$s. The Salesforce ID starts with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
-					absint( $data['wordpress_id'] )
-				);
-			}
-			$data = $this->log_object_map_error( $finish, $data );
-		}
-		return $data;
-	}
 
-	/**
-	 * Setup the error log when an objet map fails
-	 *
-	 * @param string $finish_title is a processed string depending on the error
-	 * @param array $data is what the object map was trying to do.
-	 */
-	private function log_object_map_error( $finish_title, $data ) {
-		$status = $data['status'];
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-		// log message title
-		$log_title = sprintf(
-			// translators: %1$s is the log status, %2$s is the type of WordPress object. %3$s is the finish value from the setup method, which depends on the error.
-			esc_html__( '%1$s Mapping: caused by trying to map a WordPress %2$s to Salesforce. %3$s', 'object-sync-for-salesforce' ),
-			ucfirst( esc_attr( $status ) ),
-			esc_attr( $data['wordpress_object'] ),
-			$finish_title
-		);
-		$logging->setup(
-			$log_title,
-			'',
-			0,
-			0,
-			$status
-		);
+		$data = array_intersect_key( $posted, array_flip( $allowed_fields ) );
+		return $data;
 	}
 
 	/**

--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -1347,26 +1347,26 @@ class Object_Sync_Sf_Salesforce_Push {
 			$action = 'created';
 		}
 
-		// Create object map and save it
-		$mapping_object = $this->mappings->create_object_map(
-			array(
-				'wordpress_id'      => $wordpress_object[ $id_field_name ], // wordpress unique id
-				'salesforce_id'     => $salesforce_id, // salesforce unique id. we don't care what kind of object it is at this point
-				'wordpress_object'  => $field_mapping['wordpress_object'], // keep track of what kind of wp object this is
-				'last_sync'         => current_time( 'mysql' ),
-				'last_sync_action'  => 'push',
-				'last_sync_status'  => $this->mappings->status_success,
-				'last_sync_message' => sprintf(
-					// translators: placeholder is for the action that occurred on the mapping object (pending or created)
-					esc_html__( 'Mapping object %1$s via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__,
-					esc_attr( $action )
-				),
-				'action'            => $action,
-			)
-		);
-
-		return $mapping_object;
-
+		// Create object map and save it. Only do this if we have a valid WordPress ID.
+		if ( isset( $wordpress_object[ $id_field_name ] ) ) {
+			$mapping_object = $this->mappings->create_object_map(
+				array(
+					'wordpress_id'      => $wordpress_object[ $id_field_name ], // wordpress unique id
+					'salesforce_id'     => $salesforce_id, // salesforce unique id. we don't care what kind of object it is at this point
+					'wordpress_object'  => $field_mapping['wordpress_object'], // keep track of what kind of wp object this is
+					'last_sync'         => current_time( 'mysql' ),
+					'last_sync_action'  => 'push',
+					'last_sync_status'  => $this->mappings->status_success,
+					'last_sync_message' => sprintf(
+						// translators: placeholder is for the action that occurred on the mapping object (pending or created)
+						esc_html__( 'Mapping object %1$s via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__,
+						esc_attr( $action )
+					),
+					'action'            => $action,
+				)
+			);
+			return $mapping_object;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What does this PR do?
This fixes #350 by checking for a WordPress ID before creating or updating an object map. If it does not have that value, it creates an error log.

## How do I test this PR?

I'm a little unsure how to test this yet. It's not exactly clear to me what causes this error to happen.