### PR TITLE
Add a settings field for mapping errors per page. Defaults to 50.

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -555,6 +555,7 @@ class Object_Sync_Sf_Admin {
 		$this->fields_fieldmaps( 'fieldmaps', 'objects' );
 		$this->fields_scheduling( 'schedule', 'schedule', $all_field_callbacks );
 		$this->fields_log_settings( 'log_settings', 'log_settings', $all_field_callbacks );
+		$this->fields_errors( 'mapping_errors', 'mapping_errors', $all_field_callbacks );
 	}
 
 	/**
@@ -1170,6 +1171,54 @@ class Object_Sync_Sf_Admin {
 			add_settings_field( $id, $title, $callback, $page, $section, $args );
 			register_setting( $page, $id );
 		}
+	}
+
+	/**
+	* Fields for the Mapping errors tab
+	* This runs add_settings_section once
+	*
+	* @param string $page
+	* @param string $section
+	* @param string $input_callback
+	*/
+	private function fields_errors( $page, $section, $callbacks ) {
+
+		add_settings_section( $section, __( 'Mapping Error Settings', 'object-sync-for-salesforce' ), null, $page );
+		$error_settings = array(
+			'errors_per_page' => array(
+				'title'    => __( 'Errors per page', 'object-sync-for-salesforce' ),
+				'callback' => $callbacks['text'],
+				'page'     => $page,
+				'section'  => $section,
+				'args'     => array(
+					'type'     => 'number',
+					'validate' => 'absint',
+					'default'  => 50,
+					'desc'     => __( 'Set how many mapping errors to show on a single page.', 'object-sync-for-salesforce' ),
+					'constant' => '',
+				),
+			),
+		);
+
+		foreach ( $error_settings as $key => $attributes ) {
+			$id       = $this->option_prefix . $key;
+			$name     = $this->option_prefix . $key;
+			$title    = $attributes['title'];
+			$callback = $attributes['callback'];
+			$page     = $attributes['page'];
+			$section  = $attributes['section'];
+			$args     = array_merge(
+				$attributes['args'],
+				array(
+					'title'     => $title,
+					'id'        => $id,
+					'label_for' => $id,
+					'name'      => $name,
+				)
+			);
+			add_settings_field( $id, $title, $callback, $page, $section, $args );
+			register_setting( $page, $id );
+		} // End foreach().
 	}
 
 	/**

--- a/classes/salesforce_mapping.php
+++ b/classes/salesforce_mapping.php
@@ -1033,7 +1033,7 @@ class Object_Sync_Sf_Mapping {
 	public function get_failed_object_maps() {
 		$table                 = $this->object_map_table;
 		$errors                = array();
-		$items_per_page        = 50;
+		$items_per_page        = (int) get_option( $this->option_prefix . 'errors_per_page', 50 );
 		$current_error_page    = isset( $_GET['error_page'] ) ? (int) $_GET['error_page'] : 1;
 		$offset                = ( $current_error_page * $items_per_page ) - $items_per_page;
 		$all_errors            = $this->wpdb->get_results( "SELECT * FROM ${table} WHERE salesforce_id LIKE 'tmp_sf_%' OR wordpress_id LIKE 'tmp_wp_%' LIMIT ${offset}, ${items_per_page}", ARRAY_A );

--- a/templates/admin/mapping-errors.php
+++ b/templates/admin/mapping-errors.php
@@ -3,6 +3,8 @@
 <p><?php echo esc_html__( 'For any mapping object error, you can edit (if, for example, you know the ID of the item that should be in place) or delete each database row, or you can try to track down what the plugin was doing based on the other data displayed here.', 'object-sync-for-salesforce' ); ?></p>
 <p><?php echo esc_html__( 'If you edit one of these items, and it correctly maps data between the two systems, the sync for those items will behave as normal going forward, so any edits you do after that will sync as they should.', 'object-sync-for-salesforce' ); ?></p>
 
+<?php require_once( 'settings.php' ); ?>
+
 <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>" class="error-rows">
 	<input type="hidden" name="redirect_url_error" value="<?php echo esc_url( $error_url ); ?>">
 	<input type="hidden" name="redirect_url_success" value="<?php echo esc_url( $success_url ); ?>">


### PR DESCRIPTION
## What does this PR do?

Add a settings field to the mapping errors tab for how many errors it should show per page. Defaults to 50.

## How do I test this PR?

- get more than one mapping error
- change the settings to make sure it paginates correctly.