### PR TITLE
Make sure a WordPress record is an object before loading its data and processing it

### DIFF
--- a/classes/wordpress.php
+++ b/classes/wordpress.php
@@ -362,6 +362,10 @@ class Object_Sync_Sf_WordPress {
 			$data = get_post( $object_id );
 		}
 
+		if ( ! is_object( $data ) ) {
+			return $wordpress_object;
+		}
+
 		$fields = $this->get_wordpress_object_fields( $object_type );
 		foreach ( $fields as $key => $value ) {
 			$field                      = $value['key'];


### PR DESCRIPTION
## What does this PR do?
This fixes #357. When running a WordPress action (`user_register`, etc.), this makes sure that the ID represents a WordPress object. If it fails to create a user without causing a WP error, for example, this will keep it from trying to create a Salesforce record.

## How do I test this PR?

I found this issue when testing spam users. The user wasn't being created, but it also wasn't flagging an error so the plugin was trying to move on with it. This fixes that.