### PR TITLE
create object as well as object_map in import_json_file

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1817,9 +1817,9 @@ class Object_Sync_Sf_Admin {
 			foreach ( $data['object_maps'] as $object_map ) {
 				unset( $object_map['id'] );
 
-				if( $object_map['object_type'] ) {
+				if ( $object_map['object_type'] ) {
 					$sf_sync_trigger = $this->mappings->sync_sf_create;
-					$create = $this->pull->salesforce_pull_process_records( $object_map['object_type'], $object_map['salesforce_id'], $sf_sync_trigger );
+					$create          = $this->pull->salesforce_pull_process_records( $object_map['object_type'], $object_map['salesforce_id'], $sf_sync_trigger );
 				} else {
 					$create = $this->mappings->create_object_map( $object_map );
 				}

--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1816,7 +1816,13 @@ class Object_Sync_Sf_Admin {
 		if ( isset( $data['object_maps'] ) ) {
 			foreach ( $data['object_maps'] as $object_map ) {
 				unset( $object_map['id'] );
-				$create = $this->mappings->create_object_map( $object_map );
+
+				if( $object_map['object_type'] ) {
+					$sf_sync_trigger = $this->mappings->sync_sf_create;
+					$create = $this->pull->salesforce_pull_process_records( $object_map['object_type'], $object_map['salesforce_id'], $sf_sync_trigger );
+				} else {
+					$create = $this->mappings->create_object_map( $object_map );
+				}
 				if ( false === $create ) {
 					$success = false;
 				}


### PR DESCRIPTION
I read through all the issues related to [#98](https://github.com/MinnPost/object-sync-for-salesforce/issues/98), and even though it seemed like you should be able to technically sync objects I only saw them saved to the `wp_object_sync_sf_object_map` table. This change seems to at least work for me for syncing the data in advance. I am sure it can be improved on.
```json
{
    "object_maps": [
        {
            "wordpress_object": "user",
            "salesforce_id": "0035w000034dIMuAAA"
        }
    ]
}
```

## What does this PR do?

- Makes it so that posts, users, etc are created along with the object_map on import. 

## How do I test this PR?

- create a JSON file like the following
```json
{
    "object_maps": [
        {
            "object_type": "Contact",
            "salesforce_id": "0035w000034dIMuAAA"
        }
    ]
}
```
- use the admin UI to import the file
