### PR TITLE
Remove a strict check that was incorrectly added. Thanks to WordPress user @afgarcia86 for the report.

### DIFF
--- a/classes/salesforce_push.php
+++ b/classes/salesforce_push.php
@@ -1406,8 +1406,9 @@ class Object_Sync_Sf_Salesforce_Push {
 			}
 		}
 
-		// these are bit operators, so we leave out the strict
-		if ( ! in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) {
+		// these are bit operators, so we leave out the strict.
+		// So don't ever put true in here even though WPCS complains.
+		if ( ! in_array( $sf_sync_trigger, $map_sync_triggers ) ) {
 			$push_allowed = false;
 		}
 


### PR DESCRIPTION
## What does this PR do?

This fixes #373. In 1.9.4, a strict check was incorrectly added to an array when the value is a bit value, so the strict check would fail.

## How do I test this PR?

- This affects the `push_allowed` flag.