### PR TITLE
Fix the Salesforce field dropdown so it respects the API Name/Label settings value. Thanks to @CodeZeno.

### DIFF
--- a/classes/admin.php
+++ b/classes/admin.php
@@ -1373,7 +1373,14 @@ class Object_Sync_Sf_Admin {
 		if ( empty( $data ) ) {
 			$salesforce_object = isset( $post_data['salesforce_object'] ) ? sanitize_text_field( wp_unslash( $post_data['salesforce_object'] ) ) : '';
 			$ajax              = true;
-			$attributes        = array( 'name', 'label' );
+			// here, we should respect the decision of whether to show the API name or the label
+			$display_value = get_option( $this->option_prefix . 'salesforce_field_display_value', 'field_label' );
+			if ( 'api_name' === $display_value ) {
+				$visible_label_field = 'name';
+			} else {
+				$visible_label_field = 'label';
+			}
+			$attributes = array( 'name', $visible_label_field );
 		} else {
 			$salesforce_object = isset( $data['salesforce_object'] ) ? sanitize_text_field( wp_unslash( $data['salesforce_object'] ) ) : '';
 		}

--- a/templates/admin/fieldmaps-add-edit-clone.php
+++ b/templates/admin/fieldmaps-add-edit-clone.php
@@ -384,11 +384,28 @@
 										'salesforce_object' => $salesforce_object,
 									)
 								);
+								$display_value     = get_option( $this->option_prefix . 'salesforce_field_display_value', 'field_label' );
 								foreach ( $salesforce_fields as $salesforce_field ) {
+
+									if ( 'api_name' === $display_value ) {
+										$salesforce_field['label'] = $salesforce_field['name'];
+									}
+
+									if ( false === $salesforce_field['nillable'] ) {
+										$salesforce_field['label'] .= ' *';
+									}
+
+									if ( false === $salesforce_field['updateable'] ) {
+										$locked = ' 🔒';
+									} else {
+										$locked = '';
+									}
+
 									echo sprintf(
-										'<option value="%1$s">%2$s</option>',
+										'<option value="%1$s">%2$s%3$s</option>',
 										esc_attr( $salesforce_field['name'] ),
-										esc_html( $salesforce_field['label'] )
+										esc_html( $salesforce_field['label'] ),
+										$locked
 									);
 								}
 							}


### PR DESCRIPTION
## What does this PR do?

When adding a new field to a fieldmap, the Salesforce field dropdown list wasn't respecting the plugin settings value for whether to show the API Name or Label value for the Salesforce field. This fixes #377.

## How do I test this PR?

1. Create a Fieldmap with some fields and save
2. Edit the Fieldmap and add a new field
3. Compare the list of options for the 'Salesforce Field' for an existing field and the one you just added.