### PR TITLE
Convert bit flags to more readable strings

### DIFF
--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -2363,11 +2363,17 @@ class Object_Sync_Sf_Admin {
 	 * @return array
 	 */
 	private function clear_cache( $ajax = false ) {
-		$result = (bool) $this->wordpress->sfwp_transients->flush();
-		if ( true === $result ) {
-			$message = __( 'The plugin cache has been cleared.', 'object-sync-for-salesforce' );
+		$result  = $this->wordpress->sfwp_transients->flush();
+		$success = $result['success'];
+		if ( 0 < $result['count'] ) {
+			if ( true === $success ) {
+				$message = esc_html__( 'The plugin cache has been cleared.', 'object-sync-for-salesforce' );
+			} else {
+				$message = esc_html__( 'There was an error clearing the plugin cache. Try refreshing this page.', 'object-sync-for-salesforce' );
+			}
 		} else {
-			$message = __( 'There was an error clearing the plugin cache. Try refreshing this page.', 'object-sync-for-salesforce' );
+			$success = true;
+			$message = esc_html__( 'The cache was not cleared because it is empty. You can try again later.', 'object-sync-for-salesforce' );
 		}
 		if ( false === $ajax ) {
 			// translators: parameter 1 is the result message.
@@ -2375,7 +2381,7 @@ class Object_Sync_Sf_Admin {
 		} else {
 			return array(
 				'message' => $message,
-				'success' => $result,
+				'success' => $success,
 			);
 		}
 	}

--- a/classes/class-object-sync-sf-deactivate.php
+++ b/classes/class-object-sync-sf-deactivate.php
@@ -164,8 +164,9 @@ class Object_Sync_Sf_Deactivate {
 	 * Clear the plugin options
 	 */
 	public function delete_plugin_options() {
-		$table          = $this->wpdb->prefix . 'options';
-		$plugin_options = $this->wpdb->get_results( 'SELECT option_name FROM ' . $table . ' WHERE option_name LIKE "object_sync_for_salesforce_%"', ARRAY_A );
+		$wpdb           = $this->wpdb;
+		$plugin_options = $wpdb->get_results( $wpdb->prepare( "SELECT option_name FROM `{$wpdb->base_prefix}options` WHERE option_name LIKE %s;", $wpdb->esc_like( $this->option_prefix ) . '%' ), ARRAY_A );
+
 		foreach ( $plugin_options as $option ) {
 			delete_option( $option['option_name'] );
 		}

--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -487,7 +487,7 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 			$triggers_to_log = get_option( $this->option_prefix . 'triggers_to_log', array() );
 			// if we force strict on this in_array, it fails because the mapping triggers are bit operators, as indicated in Object_Sync_Sf_Mapping class's method __construct().
 			// todo: make this not use bit operators so we can use a strict in_array.
-			if ( in_array( $trigger, maybe_unserialize( $triggers_to_log ) ) || 0 === $trigger ) {
+			if ( in_array( $trigger, maybe_unserialize( $triggers_to_log ), true ) || 0 === $trigger ) {
 				$this->add( $title, $message, $parent );
 			} elseif ( is_array( $trigger ) && array_intersect( $trigger, maybe_unserialize( $triggers_to_log ) ) ) {
 				$this->add( $title, $message, $parent );

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -418,9 +418,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 						$sf_sync_trigger = $this->mappings->sync_sf_update;
 					}
 
-					// Only queue when the record's trigger is configured for the mapping
-					// these are bit operators, so we leave out the strict.
-					if ( isset( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers ) ) { // wp or sf crud event.
+					// Only queue when the record's trigger is configured for the mapping.
+					if ( isset( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) { // wp or sf crud event.
 						$data = array(
 							'object_type'     => $type,
 							'object'          => $result,
@@ -675,9 +674,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 					} else {
 						$sf_sync_trigger = $this->mappings->sync_sf_update;
 					}
-					// Only queue when the record's trigger is configured for the mapping
-					// these are bit operators, so we leave out the strict.
-					if ( isset( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers ) ) { // wp or sf crud event.
+					// Only queue when the record's trigger is configured for the mapping.
+					if ( isset( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) { // wp or sf crud event.
 						$data = array(
 							'object_type'     => $type,
 							'object'          => $result,
@@ -803,8 +801,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 				)
 			);
 
-			// these are bit operators, so we leave out the strict.
-			if ( in_array( $this->mappings->sync_sf_create, $salesforce_mapping['sync_triggers'] ) ) {
+			// check if this is a Salesforce create event.
+			if ( in_array( $this->mappings->sync_sf_create, $salesforce_mapping['sync_triggers'], true ) ) {
 				$soql->fields['CreatedDate'] = 'CreatedDate';
 			}
 
@@ -1143,7 +1141,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$pull_allowed = true;
 
 					// if the current fieldmap does not allow delete, set pull_allowed to false.
-					if ( isset( $map_sync_triggers ) && ! in_array( $this->mappings->sync_sf_delete, $map_sync_triggers ) ) {
+					if ( isset( $map_sync_triggers ) && ! in_array( $this->mappings->sync_sf_delete, $map_sync_triggers, true ) ) {
 						$pull_allowed = false;
 					}
 
@@ -1243,7 +1241,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$salesforce_id = $object;
 			// Load the Salesforce object data to save in WordPress. We need to make sure that this data does not get cached, which is consistent with other pull behavior as well as in other methods in this class.
 			// We should only do this if we're not trying to delete data in WordPress - otherwise, we'll get a 404 from Salesforce and the delete will fail.
-			if ( $sf_sync_trigger != $this->mappings->sync_sf_delete ) { // trigger is a bit operator.
+			if ( $sf_sync_trigger !== $this->mappings->sync_sf_delete ) {
 				$object = $sfapi->object_read(
 					$object_type,
 					$salesforce_id,
@@ -1419,7 +1417,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$wordpress_id_field_name = $structure['id_field'];
 
 			// don't do parameters if we are deleting.
-			if ( ( true === $is_new && $sf_sync_trigger == $this->mappings->sync_sf_create ) || $sf_sync_trigger == $this->mappings->sync_sf_update ) { // trigger is a bit operator
+			if ( ( true === $is_new && $sf_sync_trigger === $this->mappings->sync_sf_create ) || $sf_sync_trigger === $this->mappings->sync_sf_update ) { // trigger is a bit operator
 				// map the Salesforce values to WordPress fields.
 				$params = $this->mappings->map_params( $salesforce_mapping, $object, $sf_sync_trigger, false, $is_new, $wordpress_id_field_name );
 
@@ -1451,7 +1449,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				if ( empty( $params ) ) {
 					return;
 				}
-			} elseif ( $sf_sync_trigger == $this->mappings->sync_sf_delete ) {
+			} elseif ( $sf_sync_trigger === $this->mappings->sync_sf_delete ) {
 				$is_new = false;
 			} // end checking for create/update/delete.
 
@@ -2087,7 +2085,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		$op      = '';
 
 		// deleting mapped objects.
-		if ( $sf_sync_trigger == $this->mappings->sync_sf_delete ) { // trigger is a bit operator.
+		if ( $sf_sync_trigger === $this->mappings->sync_sf_delete ) { // trigger is a bit operator.
 			if ( isset( $mapping_object['id'] ) ) {
 
 				$op = 'Delete';
@@ -2313,7 +2311,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		$pull_allowed = true;
 
 		// if the current fieldmap does not allow create, we need to check if there is an object map for the Salesforce object Id. if not, set pull_allowed to false.
-		if ( ! in_array( $this->mappings->sync_sf_create, $map_sync_triggers ) ) {
+		if ( ! in_array( $this->mappings->sync_sf_create, $map_sync_triggers, true ) ) {
 			$object_map = $this->mappings->load_all_by_salesforce( $object['Id'] );
 			if ( empty( $object_map ) ) {
 				$pull_allowed = false;

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -724,7 +724,7 @@ class Object_Sync_Sf_Salesforce_Push {
 		if ( is_int( $object ) ) {
 			$wordpress_id = $object;
 			// if this is NOT a deletion, try to get all of the object's data.
-			if ( $sf_sync_trigger != $this->mappings->sync_wordpress_delete ) { // this is a bit flag.
+			if ( $sf_sync_trigger !== $this->mappings->sync_wordpress_delete ) {
 				$object = $this->wordpress->get_wordpress_object_data( $object_type, $wordpress_id );
 			} else {
 				// otherwise, flag it as a delete and limit what we try to get.
@@ -798,9 +798,8 @@ class Object_Sync_Sf_Salesforce_Push {
 		$op     = '';
 		$result = '';
 
-		// deleting mapped objects
-		// these are bit operators, so we leave out the strict.
-		if ( $sf_sync_trigger == $this->mappings->sync_wordpress_delete ) {
+		// deleting mapped objects.
+		if ( $sf_sync_trigger === $this->mappings->sync_wordpress_delete ) {
 			if ( isset( $mapping_object['id'] ) ) {
 				$op = 'Delete';
 
@@ -1473,9 +1472,7 @@ class Object_Sync_Sf_Salesforce_Push {
 		$push_allowed = true;
 
 		// if the current fieldmap does not allow the wp create trigger, we need to check if there is an object map for the WordPress object ID. if not, set push_allowed to false.
-		// these are bit operators, so we leave out the strict.
-		// So don't ever put true in here even though WPCS complains.
-		if ( ! in_array( $this->mappings->sync_wordpress_create, $map_sync_triggers ) ) {
+		if ( ! in_array( $this->mappings->sync_wordpress_create, $map_sync_triggers, true ) ) {
 			$structure               = $this->wordpress->get_wordpress_table_structure( $object_type );
 			$wordpress_id_field_name = $structure['id_field'];
 			$object_map              = array();
@@ -1489,9 +1486,8 @@ class Object_Sync_Sf_Salesforce_Push {
 			}
 		}
 
-		// these are bit operators, so we leave out the strict.
-		// So don't ever put true in here even though WPCS complains.
-		if ( ! in_array( $sf_sync_trigger, $map_sync_triggers ) ) {
+		// check if this is a Salesforce sync trigger.
+		if ( ! in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) {
 			$push_allowed = false;
 		}
 

--- a/classes/class-object-sync-sf-wordpress-transient.php
+++ b/classes/class-object-sync-sf-wordpress-transient.php
@@ -105,7 +105,7 @@ class Object_Sync_Sf_WordPress_Transient {
 				$count++;
 			}
 		}
-		$success           = delete_transient( $this->name );
+		$success = delete_transient( $this->name );
 		if ( true === $success ) {
 			$count++;
 		}

--- a/classes/class-object-sync-sf-wordpress-transient.php
+++ b/classes/class-object-sync-sf-wordpress-transient.php
@@ -93,17 +93,25 @@ class Object_Sync_Sf_WordPress_Transient {
 	/**
 	 * Delete the entire cache for this plugin
 	 *
-	 * @return bool True if successful, false otherwise.
+	 * @return array $result has the success result and how many entries were cleared.
 	 */
 	public function flush() {
-		$keys   = $this->all_keys();
-		$result = true;
+		$keys    = $this->all_keys();
+		$success = true;
+		$count   = 0;
 		if ( ! empty( $keys ) ) {
 			foreach ( $keys as $key ) {
-				$result = delete_transient( $key );
+				$success = delete_transient( $key );
+				$count++;
 			}
 		}
-		$result = delete_transient( $this->name );
+		$success           = delete_transient( $this->name );
+		if ( true === $success ) {
+			$count++;
+		}
+		$result            = array();
+		$result['success'] = $success;
+		$result['count']   = $count;
 		return $result;
 	}
 


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #375 by converting the bit flags that came over from Drupal into strings that are more readable, and can be used in strict comparisons as well.

## How do I test this Pull Request?

- make sure the log settings and the fieldmap settings show the correct values after switching to version 2.0.0 of the plugin
- make sure the push and pull events work the way they should for create, update, delete
- make sure the log entries are stored correctly