### PR TITLE
Remove deprecated methods from prior to version 2.0.0.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ Changelog
 		* `public static $instance;` is a legacy way of loading an instance of this plugin.
 		* `check_for_action_scheduler` is a method of the `Object_Sync_Sf_Activate` class to ensure that the plugin has successfully loaded the ActionScheduler library.
 		* bit flags from the `Object_Sync_Sf_Mapping` class have been converted to strings. The old bit flags are still there with `_v1` suffixed to their property names.
+		* `get_object_maps` from the `Object_Sync_Sf_Mapping` class was previously deprecated, but was still being called in various places. It no longer is.
 
 
 * 1.10.0 (2021-05-14)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ Changelog
 	* Bug fix: in some cases, calls to the Salesforce SOAP API, which runs to detect merged records, was not able to complete. This should now be more reliable functionality.
 	* Maintenance: most files in this plugin have been renamed, and are now being autoloaded when the plugin needs them. This should help performance, future maintenance, and makes it possible to better comply with the WordPress Code Standards. This means if you are manually calling any plugin files, you may need to change your code.
 	* Maintenance: this release includes a lot of code improvements to better match the WordPress Code Standards and improve code readability. This includes converting a previous set of bit flags to strings. This is generally a backward-compatible change, as it updates the database when the upgrade is complete.
+	* Developers: some methods that were deprecated in previous versions were removed. Removed items in 2.0.0:
+		* `add_deprecated_actions` in  `Object_Sync_Sf_Admin`.
+		* `get_wp_sf_object_fields` in `Object_Sync_Sf_Admin`.
 	* Developers: this release deprecates some functionality from previous versions. It is always marked in the codebase as `@deprecated`. It may be removed in a future 3.x version and should be, if possible, moved away from. Deprecated items in 2.0.0:
 		* `public static $instance;` is a legacy way of loading an instance of this plugin.
 		* `check_for_action_scheduler` is a method of the `Object_Sync_Sf_Activate` class to ensure that the plugin has successfully loaded the ActionScheduler library.

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ Changelog
 	* Bug fix: in some cases, calls to the Salesforce SOAP API, which runs to detect merged records, was not able to complete. This should now be more reliable functionality.
 	* Maintenance: most files in this plugin have been renamed, and are now being autoloaded when the plugin needs them. This should help performance, future maintenance, and makes it possible to better comply with the WordPress Code Standards. This means if you are manually calling any plugin files, you may need to change your code.
 	* Maintenance: this release includes a lot of code improvements to better match the WordPress Code Standards and improve code readability. This includes converting a previous set of bit flags to strings. This is generally a backward-compatible change, as it updates the database when the upgrade is complete.
+	* Developers: this release deprecates some functionality from previous versions. It is always marked in the codebase as `@deprecated`. It may be removed in a future 3.x version and should be, if possible, moved away from. Deprecated items in 2.0.0:
+		* `public static $instance;` is a legacy way of loading an instance of this plugin.
+		* `check_for_action_scheduler` is a method of the `Object_Sync_Sf_Activate` class to ensure that the plugin has successfully loaded the ActionScheduler library.
+		* bit flags from the `Object_Sync_Sf_Mapping` class have been converted to strings. The old bit flags are still there with `_v1` suffixed to their property names.
+
 
 * 1.10.0 (2021-05-14)
     * Feature: Add support for Advanced Custom Fields forms that save posts on the front end. Thanks to WordPress user @grayzee for the request.

--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,10 @@ Changelog
 	* Maintenance: most files in this plugin have been renamed, and are now being autoloaded when the plugin needs them. This should help performance, future maintenance, and makes it possible to better comply with the WordPress Code Standards. This means if you are manually calling any plugin files, you may need to change your code.
 	* Maintenance: this release includes a lot of code improvements to better match the WordPress Code Standards and improve code readability. This includes converting a previous set of bit flags to strings. This is generally a backward-compatible change, as it updates the database when the upgrade is complete.
 	* Developers: some methods that were deprecated in previous versions were removed. Removed items in 2.0.0:
-		* `add_deprecated_actions` in  `Object_Sync_Sf_Admin`.
-		* `get_wp_sf_object_fields` in `Object_Sync_Sf_Admin`.
+		* `add_deprecated_actions` in  `Object_Sync_Sf_Admin`
+		* `get_wp_sf_object_fields` in `Object_Sync_Sf_Admin`
+		* `load_by_wordpress` in `Object_Sync_Sf_Mapping`
+		* `load_by_salesforce` in `Object_Sync_Sf_Mapping`
 	* Developers: this release deprecates some functionality from previous versions. It is always marked in the codebase as `@deprecated`. It may be removed in a future 3.x version and should be, if possible, moved away from. Deprecated items in 2.0.0:
 		* `public static $instance;` is a legacy way of loading an instance of this plugin.
 		* `check_for_action_scheduler` is a method of the `Object_Sync_Sf_Activate` class to ensure that the plugin has successfully loaded the ActionScheduler library.

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1944,13 +1944,7 @@ class Object_Sync_Sf_Admin {
 				}
 			}
 			if ( isset( $data['object_maps'] ) ) {
-				$object_maps = $this->mappings->get_object_maps();
-
-				// if there is only one existing object map, fix the array.
-				if ( count( $object_maps ) === count( $object_maps, COUNT_RECURSIVE ) ) {
-					$object_maps = array( 0 => $object_maps );
-				}
-
+				$object_maps = $this->mappings->get_all_object_maps();
 				foreach ( $object_maps as $object_map ) {
 					$id     = $object_map['id'];
 					$delete = $this->mappings->delete_object_map( $id );

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1404,6 +1404,12 @@ class Object_Sync_Sf_Admin {
 				'type'        => 'success',
 				'dismissible' => true,
 			),
+			'data_save_partial'       => array(
+				'condition'   => isset( $get_data['data_saved'] ) && 'partial' === $get_data['data_saved'],
+				'message'     => __( 'This data was partially successfully saved. This means some of the data was unable to save. If you have enabled logging in the plugin settings, there should be a log entry with further details.', 'object-sync-for-salesforce' ),
+				'type'        => 'error',
+				'dismissible' => true,
+			),
 			'data_save_error'         => array(
 				'condition'   => isset( $get_data['data_saved'] ) && 'false' === $get_data['data_saved'],
 				'message'     => __( 'This data was not successfully saved. Try again.', 'object-sync-for-salesforce' ),
@@ -1927,13 +1933,6 @@ class Object_Sync_Sf_Admin {
 		// Retrieve the data from the file and convert the json object to an array.
 		$data = (array) json_decode( file_get_contents( $import_file ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
-		// if there is only one object map, fix the array.
-		if ( isset( $data['object_maps'] ) ) {
-			if ( count( $data['object_maps'] ) === count( $data['object_maps'], COUNT_RECURSIVE ) ) {
-				$data['object_maps'] = array( 0 => $data['object_maps'] );
-			}
-		}
-
 		$overwrite = isset( $_POST['overwrite'] ) ? esc_attr( $_POST['overwrite'] ) : '';
 		if ( true === filter_var( $overwrite, FILTER_VALIDATE_BOOLEAN ) ) {
 			if ( isset( $data['fieldmaps'] ) ) {
@@ -1970,17 +1969,20 @@ class Object_Sync_Sf_Admin {
 		}
 
 		if ( isset( $data['object_maps'] ) ) {
+			$successful_object_maps = array();
+			$error_object_maps      = array();
 			foreach ( $data['object_maps'] as $object_map ) {
 				unset( $object_map['id'] );
-
-				if ( $object_map['object_type'] ) {
+				if ( isset( $object_map['object_type'] ) ) {
 					$sf_sync_trigger = $this->mappings->sync_sf_create;
 					$create          = $this->pull->salesforce_pull_process_records( $object_map['object_type'], $object_map['salesforce_id'], $sf_sync_trigger );
 				} else {
 					$create = $this->mappings->create_object_map( $object_map );
 				}
 				if ( false === $create ) {
-					$success = false;
+					$error_object_maps[] = $object_map;
+				} else {
+					$successful_object_maps[] = $create;
 				}
 			}
 		}
@@ -1991,9 +1993,42 @@ class Object_Sync_Sf_Admin {
 			}
 		}
 
-		if ( true === $success ) {
+		$status = 'error';
+		if ( isset( $this->logging ) ) {
+			$logging = $this->logging;
+		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+		}
+
+		$body = sprintf( esc_html__( 'These are the import items that were not able to save: ', 'object-sync-for-salesforce' ) . '<ul>' );
+		foreach ( $error_object_maps as $mapping_object ) {
+			$body .= sprintf(
+				// translators: placeholders are: 1) the mapping object row ID, 2) the ID of the Salesforce object, 3) the WordPress object type.
+				'<li>' . esc_html__( 'Mapping object id (if it exists): %1$s. Salesforce Id: %2$s. WordPress object type: %3$s', 'object-sync-for-salesforce' ) . '</li>',
+				isset( $mapping_object['id'] ) ? absint( $mapping_object['id'] ) : '',
+				esc_attr( $mapping_object['salesforce_id'] ),
+				esc_attr( $mapping_object['wordpress_object'] )
+			);
+		}
+		$body .= sprintf( '</ul>' );
+
+		$logging->setup(
+			sprintf(
+				// translators: %1$s is the log status.
+				esc_html__( '%1$s on import: some of the rows were unable to save. Read this post for details.', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) )
+			),
+			$body,
+			0,
+			0,
+			$status
+		);
+
+		if ( empty( $error_object_maps ) && ! empty( $successful_object_maps ) ) {
 			wp_safe_redirect( get_admin_url( null, 'options-general.php?page=' . $this->admin_settings_url_param . '&tab=import-export&data_saved=true' ) );
 			exit;
+		} elseif ( ! empty( $error_object_maps ) && ! empty( $successful_object_maps ) ) {
+			wp_safe_redirect( get_admin_url( null, 'options-general.php?page=' . $this->admin_settings_url_param . '&tab=import-export&data_saved=partial' ) );
 		} else {
 			wp_safe_redirect( get_admin_url( null, 'options-general.php?page=' . $this->admin_settings_url_param . '&tab=import-export&data_saved=false' ) );
 			exit;
@@ -2018,7 +2053,7 @@ class Object_Sync_Sf_Admin {
 			$export['fieldmaps'] = $this->mappings->get_fieldmaps();
 		}
 		if ( in_array( 'object_maps', $post_data['export'], true ) ) {
-			$export['object_maps'] = $this->mappings->get_object_maps();
+			$export['object_maps'] = $this->mappings->get_all_object_maps();
 		}
 		if ( in_array( 'plugin_settings', $post_data['export'], true ) ) {
 			$wpdb                      = $this->wpdb;

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -2489,15 +2489,16 @@ class Object_Sync_Sf_Admin {
 	public function save_salesforce_user_fields( $user_id ) {
 		$post_data = filter_input_array( INPUT_POST, FILTER_SANITIZE_STRING );
 		if ( isset( $post_data['salesforce_update_mapped_user'] ) && true === filter_var( $post_data['salesforce_update_mapped_user'], FILTER_VALIDATE_BOOLEAN ) ) {
-			$mapping_object                  = $this->mappings->get_object_maps(
+			$mapping_objects = $this->mappings->get_all_object_maps(
 				array(
 					'wordpress_id'     => $user_id,
 					'wordpress_object' => 'user',
 				)
 			);
-			$mapping_object['salesforce_id'] = $post_data['salesforce_id'];
-
-			$result = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+			foreach ( $mapping_objects as $mapping_object ) {
+				$mapping_object['salesforce_id'] = $post_data['salesforce_id'];
+				$result                          = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
+			}
 		} elseif ( isset( $post_data['salesforce_create_mapped_user'] ) && true === filter_var( $post_data['salesforce_create_mapped_user'], FILTER_VALIDATE_BOOLEAN ) ) {
 			// if a Salesforce ID was entered.
 			if ( isset( $post_data['salesforce_id'] ) && ! empty( $post_data['salesforce_id'] ) ) {

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1699,15 +1699,23 @@ class Object_Sync_Sf_Admin {
 		if ( empty( $mapping_id ) ) {
 			$mapping_id = isset( $post_data['mapping_id'] ) ? absint( $post_data['mapping_id'] ) : '';
 		}
-		$result = $this->mappings->get_object_maps(
+		$result = $this->mappings->get_all_object_maps(
 			array(
 				'id' => $mapping_id,
 			)
 		);
+
+		$object_map = array();
+
+		// result is an array of arrays, not just one array.
+		if ( 1 === count( $result ) ) {
+			$object_map = $result[0];
+		}
+
 		if ( ! empty( $post_data ) ) {
-			wp_send_json_success( $result );
+			wp_send_json_success( $object_map );
 		} else {
-			return $result;
+			return $object_map;
 		}
 	}
 

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -245,8 +245,6 @@ class Object_Sync_Sf_Admin {
 		$this->default_updateable = true;
 
 		$this->add_actions();
-
-		$this->add_deprecated_actions();
 	}
 
 	/**
@@ -305,24 +303,6 @@ class Object_Sync_Sf_Admin {
 		add_action( 'admin_post_object_sync_for_salesforce_import', array( $this, 'import_json_file' ) );
 		add_action( 'admin_post_object_sync_for_salesforce_export', array( $this, 'export_json_file' ) );
 
-	}
-
-	/**
-	 * Deprecated action hooks for admin pages
-	 */
-	private function add_deprecated_actions() {
-		/**
-		 * Method: get_wordpress_object_description
-		 *
-		 * @deprecated since 1.9.0
-		 */
-		add_action( 'wp_ajax_get_wordpress_object_description', array( $this, 'get_wordpress_object_fields' ), 10, 1 );
-		/**
-		 * Method: get_wp_sf_object_fields
-		 *
-		 * @deprecated since 1.9.0
-		 */
-		add_action( 'wp_ajax_get_wp_sf_object_fields', array( $this, 'get_wp_sf_object_fields' ), 10, 2 );
 	}
 
 	/**
@@ -1599,38 +1579,6 @@ class Object_Sync_Sf_Admin {
 				'fields' => $object_fields,
 			);
 			wp_send_json_success( $ajax_response );
-		} else {
-			return $object_fields;
-		}
-	}
-
-	/**
-	 * Get WordPress and Salesforce object fields together for fieldmapping
-	 * This takes either the $_POST array via ajax, or can be directly called with $wordpress_object and $salesforce_object fields
-	 *
-	 * @deprecated since 1.9.0
-	 * @param string $wordpress_object is the name of the WordPress object.
-	 * @param string $salesforce_object is the name of the Salesforce object.
-	 * @return array $object_fields
-	 */
-	public function get_wp_sf_object_fields( $wordpress_object = '', $salesforce_object = '' ) {
-		$post_data = filter_input_array( INPUT_POST, FILTER_SANITIZE_STRING );
-		if ( empty( $wordpress_object ) ) {
-			$wordpress_object = isset( $post_data['wordpress_object'] ) ? sanitize_text_field( wp_unslash( $post_data['wordpress_object'] ) ) : '';
-		}
-		if ( empty( $salesforce_object ) ) {
-			$salesforce_object = isset( $post_data['salesforce_object'] ) ? sanitize_text_field( wp_unslash( $post_data['salesforce_object'] ) ) : '';
-		}
-
-		$object_fields['wordpress']  = $this->get_wordpress_object_fields( $wordpress_object );
-		$object_fields['salesforce'] = $this->get_salesforce_object_fields(
-			array(
-				'salesforce_object' => $salesforce_object,
-			)
-		);
-
-		if ( ! empty( $post_data ) ) {
-			wp_send_json_success( $object_fields );
 		} else {
 			return $object_fields;
 		}

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -709,10 +709,10 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Get one or more object map rows between WordPress and Salesforce objects
 	 *
-	 * @deprecated since 1.8.0
 	 * @param array $conditions Limitations on the SQL query for object mapping rows.
 	 * @param bool  $reset Unused parameter.
 	 * @return array $map or $mappings
+	 * @deprecated since 1.8.0
 	 */
 	public function get_object_maps( $conditions = array(), $reset = false ) {
 		$table = $this->object_map_table;

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -851,24 +851,6 @@ class Object_Sync_Sf_Mapping {
 	}
 
 	/**
-	 * Returns one or more Salesforce object mappings for a given WordPress object.
-	 *
-	 * @deprecated since 1.8.0
-	 * @param string $object_type Type of object to load.
-	 * @param int    $object_id Unique identifier of the target object to load.
-	 * @param bool   $reset Whether or not the cache should be cleared and fetch from current data.
-	 *
-	 * @return array of a single object map
-	 */
-	public function load_by_wordpress( $object_type, $object_id, $reset = false ) {
-		$conditions = array(
-			'wordpress_id'     => $object_id,
-			'wordpress_object' => $object_type,
-		);
-		return $this->get_object_maps( $conditions, $reset );
-	}
-
-	/**
 	 * Returns Salesforce object mappings for a given Salesforce object.
 	 *
 	 * @param string $salesforce_id Type of object to load.
@@ -884,61 +866,6 @@ class Object_Sync_Sf_Mapping {
 		$maps = $this->get_all_object_maps( $conditions, $reset );
 
 		return $maps;
-	}
-
-	/**
-	 * Returns one or more Salesforce object mappings for a given Salesforce object.
-	 *
-	 * @deprecated since 1.8.0
-	 * @param string $salesforce_id Type of object to load.
-	 * @param bool   $reset Whether or not the cache should be cleared and fetch from current data.
-	 *
-	 * @return array $map The most recent fieldmap
-	 */
-	public function load_by_salesforce( $salesforce_id, $reset = false ) {
-		$conditions = array(
-			'salesforce_id' => $salesforce_id,
-		);
-
-		$map = $this->get_object_maps( $conditions, $reset );
-
-		if ( isset( $map[0] ) && is_array( $map[0] ) && count( $map ) > 1 ) {
-			$status = 'notice';
-			$log    = '';
-			$log   .= 'Mapping: there is more than one mapped WordPress object for the Salesforce object ' . $salesforce_id . '. These WordPress IDs are: ';
-			$i      = 0;
-			foreach ( $map as $mapping ) {
-				$i++;
-				if ( isset( $mapping['wordpress_id'] ) ) {
-					$log .= 'object type: ' . $mapping['wordpress_object'] . ', id: ' . $mapping['wordpress_id'];
-				}
-				if ( count( $map ) !== $i ) {
-					$log .= '; ';
-				} else {
-					$log .= '.';
-				}
-			}
-			$map = $map[0];
-			// Create log entry for multiple maps.
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-			$logging->setup(
-				sprintf(
-					// translators: %1$s is the Id of a Salesforce object.
-					esc_html__( 'Notice: Mapping: there is more than one mapped WordPress object for the Salesforce object %2$s', 'object-sync-for-salesforce' ),
-					esc_attr( $salesforce_id )
-				),
-				$log,
-				0,
-				0,
-				$status
-			);
-		} // End if() statement.
-
-		return $map;
 	}
 
 	/**

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -257,7 +257,7 @@ class Object_Sync_Sf_Mapping {
 		$this->sync_sf_update        = 'sf_update';
 		$this->sync_sf_delete        = 'sf_delete';
 
-		// deprecated bit flags from version 1.x.
+		// deprecated bit flags from version 1.x. Deprecated since 2.0.0.
 		$this->sync_off_v1              = 0x0000;
 		$this->sync_wordpress_create_v1 = 0x0001;
 		$this->sync_wordpress_update_v1 = 0x0002;
@@ -270,7 +270,7 @@ class Object_Sync_Sf_Mapping {
 		$this->wordpress_events  = array( $this->sync_wordpress_create, $this->sync_wordpress_update, $this->sync_wordpress_delete );
 		$this->salesforce_events = array( $this->sync_sf_create, $this->sync_sf_update, $this->sync_sf_delete );
 
-		// deprecated bit flags from version 1.x.
+		// deprecated bit flags from version 1.x. Deprecated since 2.0.0.
 		$this->wordpress_events_v1  = array( $this->sync_wordpress_create_v1, $this->sync_wordpress_update_v1, $this->sync_wordpress_delete_v1 );
 		$this->salesforce_events_v1 = array( $this->sync_sf_create_v1, $this->sync_sf_update_v1, $this->sync_sf_delete_v1 );
 

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1616,7 +1616,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							'wordpress_object' => $salesforce_mapping['wordpress_object'],
 						)
 					);
-					if ( is_array( $mapping_objects[0] ) ) {
+					if ( isset( $mapping_objects[0] ) && is_array( $mapping_objects[0] ) ) {
 						$mapping_object = $mapping_objects[0];
 					}
 				} else {
@@ -1745,7 +1745,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						'id' => $mapping_object_id,
 					)
 				);
-				if ( is_array( $mapping_objects[0] ) ) {
+				if ( isset( $mapping_objects[0] ) && is_array( $mapping_objects[0] ) ) {
 					$mapping_object = $mapping_objects[0];
 				}
 				// now we can upsert the object in wp if we've gotten to this point
@@ -1763,7 +1763,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						'id' => $mapping_object_id,
 					)
 				);
-				if ( is_array( $mapping_objects[0] ) ) {
+				if ( isset( $mapping_objects[0] ) && is_array( $mapping_objects[0] ) ) {
 					$mapping_object = $mapping_objects[0];
 				}
 

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -996,11 +996,15 @@ class Object_Sync_Sf_Salesforce_Push {
 			$mapping_object_id = $this->create_object_map( $object, $wordpress_id_field_name, $temporary_map_id, $mapping, true );
 			set_transient( 'salesforce_pushing_' . $temporary_map_id, 1, $seconds );
 			set_transient( 'salesforce_pushing_object_id', $temporary_map_id );
-			$mapping_object = $this->mappings->get_object_maps(
+			$mapping_object  = array();
+			$mapping_objects = $this->mappings->get_all_object_maps(
 				array(
 					'id' => $mapping_object_id,
 				)
 			);
+			if ( is_array( $mapping_objects[0] ) ) {
+				$mapping_object = $mapping_objects[0];
+			}
 
 			// setup SF record type. CampaignMember objects get their Campaign's type
 			// i am still a bit confused about this.

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -1002,7 +1002,7 @@ class Object_Sync_Sf_Salesforce_Push {
 					'id' => $mapping_object_id,
 				)
 			);
-			if ( is_array( $mapping_objects[0] ) ) {
+			if ( isset( $mapping_objects[0] ) && is_array( $mapping_objects[0] ) ) {
 				$mapping_object = $mapping_objects[0];
 			}
 


### PR DESCRIPTION
## What does this Pull Request do?

### removed methods
-  `add_deprecated_actions` in  `Object_Sync_Sf_Admin`
- `get_wp_sf_object_fields` in `Object_Sync_Sf_Admin`
- `load_by_wordpress` in `Object_Sync_Sf_Mapping`
- `load_by_salesforce` in `Object_Sync_Sf_Mapping`

### edited deprecation
`get_object_maps` from the `Object_Sync_Sf_Mapping` class was previously deprecated, but was still being called in various places. It no longer is.

This closes #336.

## How do I test this Pull Request?

- make sure push and pull requests run as expected
- make sure fieldmap adding/editing works as expected