### PR TITLE
Improve the log message when an update to a WordPress record fails

### DIFF
--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1948,7 +1948,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		try {
 
 			$op     = 'Update';
-			$result = $this->wordpress->object_update( $salesforce_mapping['wordpress_object'], $mapping_object['wordpress_id'], $params );
+			$result = $this->wordpress->object_update( $salesforce_mapping['wordpress_object'], $mapping_object['wordpress_id'], $params, $mapping_object );
 
 			$mapping_object['last_sync_status']  = $this->mappings->status_success;
 			$mapping_object['last_sync_message'] = esc_html__( 'Mapping object updated via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__;


### PR DESCRIPTION
## What does this Pull Request do?

When the plugin tries to update a record in WordPress and it fails, we've previously only logged the error message and the WordPress ID. This adds to that log message the Salesforce object ID and the parameters the plugin was trying to update.

## How do I test this Pull Request?

- one way would be to successfully sync two records and then delete the WordPress record without deleting the object map from the database.
- The other is to code a value into `$result['errors']` in the WordPress class right before it creates this log entry.