### PR TITLE
Fix missing Record Type when pulled from Salesforce. Thanks to @timnolte for the report.

### DIFF
--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -1119,12 +1119,12 @@ class Object_Sync_Sf_Mapping {
 			$mappings[ $id ]['salesforce_record_types_allowed'] = isset( $mapping['salesforce_record_types_allowed'] ) ? maybe_unserialize( $mapping['salesforce_record_types_allowed'] ) : array();
 			$mappings[ $id ]['fields']                          = isset( $mapping['fields'] ) ? maybe_unserialize( $mapping['fields'] ) : array();
 			$mappings[ $id ]['sync_triggers']                   = isset( $mapping['sync_triggers'] ) ? maybe_unserialize( $mapping['sync_triggers'] ) : array();
-			if ( '' !== $record_type && ! in_array( $record_type, $mappings[ $id ]['salesforce_record_types_allowed'], true ) ) {
-				unset( $mappings[ $id ] );
-			}
 			// format the sync triggers.
 			$sync_triggers                    = $this->maybe_upgrade_sync_triggers( $mappings[ $id ]['sync_triggers'], $mapping['version'], $mapping['id'] );
 			$mappings[ $id ]['sync_triggers'] = $sync_triggers;
+			if ( '' !== $record_type && ! in_array( $record_type, $mappings[ $id ]['salesforce_record_types_allowed'], true ) ) {
+				unset( $mappings[ $id ] );
+			}
 		}
 		return $mappings;
 	}


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #418.

>  After upgrading to the 2.x version of the plugin I have found that specifically in the case where I have multiple mappings for a Salesforce Object to a WordPress Object, because of multiple Salesforce record Types, that when those records from Salesforce are being processed the resulting WordPress Post Type ends up being set as `post`, when logs and debug processing indicate that it should have created a Custom Post Type (e.g. `sf_industry_location`). I verified that reverting back to the 1.9.9 version of the plugin restored the proper WordPress Post Type is created.

## How do I test this Pull Request?

- Setup 2 or more Fieldmappings to the same WordPress Custom Post Type against a Salesforce Object with multiple record Types. (1 mapping per record type.)
- Modify or create one of those records in Salesforce.
- Wait for the WordPress instance to pull the Salesforce change.
- Observe that a standard WordPress post is created and not the Custom Post Type specified in the Fieldmapping.
