### PR TITLE
Create a log entry if the plugin tries to sync a record but no parameters are eligible. Thanks to @OfficeBureau for the report.

### DIFF
--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -1102,61 +1102,6 @@ class Object_Sync_Sf_Mapping {
 			return array();
 		}
 
-		// if the parameters array is empty at this point, we should create a log entry to that effect.
-		// I think it should be a debug message, unless we learn from users that it should be raised to an error.
-		if ( empty( $params ) ) {
-			$status = 'debug';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
-			$title = sprintf(
-				// translators: %1$s is the log status.
-				esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in this object map that can be synced.', 'object-sync-for-salesforce' ),
-				ucfirst( esc_attr( $status ) )
-			);
-
-			$body = '';
-
-			// whether it's a new mapping object or not.
-			if ( false === $is_new ) {
-				// this one is not new.
-				$body .= sprintf(
-					// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
-					esc_html__( 'There is an object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s', 'object-sync-for-salesforce' ),
-					absint( $mapping['id'] ),
-					esc_attr( $mapping['wordpress_object'] ),
-					esc_attr( $mapping['wordpress_id'] ),
-					esc_attr( $mapping['salesforce_id'] )
-				);
-			} else {
-				// this one is new.
-				$body .= sprintf(
-					// translators: placeholders are: 1) the name of the WordPress object, 2) the ID of the WordPress object, 3) the ID of the Salesforce object it was trying to map.
-					esc_html__( 'The plugin was trying to create a new object map between the WordPress %1$s with ID of %2$s and the Salesforce object with ID of %3$s', 'object-sync-for-salesforce' ),
-					esc_attr( $mapping['wordpress_object'] ),
-					esc_attr( $mapping['wordpress_id'] ),
-					esc_attr( $mapping['salesforce_id'] )
-				);
-			}
-
-			$body = sprintf(
-				// translators: placeholders are 1) the object's data that was attempted.
-				'<p>' . esc_html__( 'The object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
-				print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			);
-
-			$logging->setup(
-				$title,
-				$body,
-				$trigger,
-				0,
-				$status
-			);
-		}
-
 		return $params;
 
 	}

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1393,7 +1393,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$structure               = $this->wordpress->get_wordpress_table_structure( $salesforce_mapping['wordpress_object'] );
 			$wordpress_id_field_name = $structure['id_field'];
 
-			// don't do parameters if we are deleting.
+			// only deal with parameters if we are not deleting.
 			if ( ( true === $is_new && $sf_sync_trigger === $this->mappings->sync_sf_create ) || $sf_sync_trigger === $this->mappings->sync_sf_update ) { // trigger is a bit operator
 				// map the Salesforce values to WordPress fields.
 				$params = $this->mappings->map_params( $salesforce_mapping, $object, $sf_sync_trigger, false, $is_new, $wordpress_id_field_name );
@@ -1427,6 +1427,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					return;
 				}
 			} elseif ( $sf_sync_trigger === $this->mappings->sync_sf_delete ) {
+				// this is a deletion. don't deal with parameters.
 				$is_new = false;
 			} // end checking for create/update/delete.
 

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1427,65 +1427,67 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 					// if the parameters array is empty at this point, we should create a log entry to that effect.
 					// I think it should be a debug message, unless we learn from users that it should be raised to an error.
-					$status = 'debug';
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
+					if ( true === $this->debug ) {
+						$status = 'debug';
+						if ( isset( $this->logging ) ) {
+							$logging = $this->logging;
+						} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+							$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+						}
 
-					$title = sprintf(
-						// translators: %1$s is the log status.
-						esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pulled from Salesforce.', 'object-sync-for-salesforce' ),
-						ucfirst( esc_attr( $status ) )
-					);
+						$title = sprintf(
+							// translators: %1$s is the log status.
+							esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pulled from Salesforce.', 'object-sync-for-salesforce' ),
+							ucfirst( esc_attr( $status ) )
+						);
 
-					$body = '';
+						$body = '';
 
-					$body .= sprintf(
-						// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
-						'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
-						absint( $salesforce_mapping['id'] ),
-						esc_attr( $salesforce_mapping['wordpress_object'] ),
-						esc_attr( $salesforce_mapping['salesforce_object'] )
-					);
+						$body .= sprintf(
+							// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
+							'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
+							absint( $salesforce_mapping['id'] ),
+							esc_attr( $salesforce_mapping['wordpress_object'] ),
+							esc_attr( $salesforce_mapping['salesforce_object'] )
+						);
 
-					// whether it's a new mapping object or not.
-					if ( false === $is_new ) {
-						// this one is not new.
-						foreach ( $mapping_objects as $mapping_object ) {
+						// whether it's a new mapping object or not.
+						if ( false === $is_new ) {
+							// this one is not new.
+							foreach ( $mapping_objects as $mapping_object ) {
+								$body .= sprintf(
+									// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
+									'<p>' . esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ) . '</p>',
+									absint( $mapping_object['id'] ),
+									esc_attr( $mapping_object['wordpress_object'] ),
+									esc_attr( $mapping_object['wordpress_id'] ),
+									esc_attr( $mapping_object['salesforce_id'] )
+								);
+							}
+						} else {
+							// this one is new.
 							$body .= sprintf(
-								// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
-								'<p>' . esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ) . '</p>',
-								absint( $mapping_object['id'] ),
-								esc_attr( $mapping_object['wordpress_object'] ),
-								esc_attr( $mapping_object['wordpress_id'] ),
-								esc_attr( $mapping_object['salesforce_id'] )
+								// translators: placeholders are: 1) the ID of the Salesforce object, 2) the WordPress object type.
+								'<p>' . esc_html__( 'The plugin was trying to pull the Salesforce object with ID of %1$s to the WordPress %2$s object type.', 'object-sync-for-salesforce' ) . '</p>',
+								esc_attr( $object['Id'] ),
+								esc_attr( $salesforce_mapping['wordpress_object'] )
 							);
 						}
-					} else {
-						// this one is new.
+
 						$body .= sprintf(
-							// translators: placeholders are: 1) the ID of the Salesforce object, 2) the WordPress object type.
-							'<p>' . esc_html__( 'The plugin was trying to pull the Salesforce object with ID of %1$s to the WordPress %2$s object type.', 'object-sync-for-salesforce' ) . '</p>',
-							esc_attr( $object['Id'] ),
-							esc_attr( $salesforce_mapping['wordpress_object'] )
+							// translators: placeholders are 1) the object's data that was attempted.
+							'<p>' . esc_html__( 'The Salesforce object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
+							print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 						);
-					}
 
-					$body .= sprintf(
-						// translators: placeholders are 1) the object's data that was attempted.
-						'<p>' . esc_html__( 'The Salesforce object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
-						print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-					);
-
-					$logging->setup(
-						$title,
-						$body,
-						$sf_sync_trigger,
-						0,
-						$status
-					);
+						$logging->setup(
+							$title,
+							$body,
+							$sf_sync_trigger,
+							0,
+							$status
+						);
+					} // end debug mode check.
 
 					continue;
 				} // end if params are empty.

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1488,7 +1488,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					);
 
 					continue;
-				}
+				} // end if params are empty.
 			} elseif ( $sf_sync_trigger === $this->mappings->sync_sf_delete ) {
 				// this is a deletion. don't deal with parameters.
 				$is_new = false;

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1185,7 +1185,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		$code = '201';
 		foreach ( $results as $result ) {
-			if ( 'success' !== $result['status'] ) {
+			if ( ! isset( $result['status'] ) || 'success' !== $result['status'] ) {
 				$code = '403';
 			}
 		}
@@ -1424,7 +1424,70 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 				// if we don't get any params, there are no fields that should be sent to WordPress.
 				if ( empty( $params ) ) {
-					return;
+
+					// if the parameters array is empty at this point, we should create a log entry to that effect.
+					// I think it should be a debug message, unless we learn from users that it should be raised to an error.
+					$status = 'debug';
+					if ( isset( $this->logging ) ) {
+						$logging = $this->logging;
+					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+					}
+
+					$title = sprintf(
+						// translators: %1$s is the log status.
+						esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pulled from Salesforce.', 'object-sync-for-salesforce' ),
+						ucfirst( esc_attr( $status ) )
+					);
+
+					$body = '';
+
+					$body .= sprintf(
+						// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
+						'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
+						absint( $salesforce_mapping['id'] ),
+						esc_attr( $salesforce_mapping['wordpress_object'] ),
+						esc_attr( $salesforce_mapping['salesforce_object'] )
+					);
+
+					// whether it's a new mapping object or not.
+					if ( false === $is_new ) {
+						// this one is not new.
+						foreach ( $mapping_objects as $mapping_object ) {
+							$body .= sprintf(
+								// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
+								'<p>' . esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ) . '</p>',
+								absint( $mapping_object['id'] ),
+								esc_attr( $mapping_object['wordpress_object'] ),
+								esc_attr( $mapping_object['wordpress_id'] ),
+								esc_attr( $mapping_object['salesforce_id'] )
+							);
+						}
+					} else {
+						// this one is new.
+						$body .= sprintf(
+							// translators: placeholders are: 1) the ID of the Salesforce object, 2) the WordPress object type.
+							'<p>' . esc_html__( 'The plugin was trying to pull the Salesforce object with ID of %1$s to the WordPress %2$s object type.', 'object-sync-for-salesforce' ) . '</p>',
+							esc_attr( $object['Id'] ),
+							esc_attr( $salesforce_mapping['wordpress_object'] )
+						);
+					}
+
+					$body .= sprintf(
+						// translators: placeholders are 1) the object's data that was attempted.
+						'<p>' . esc_html__( 'The Salesforce object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
+						print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+					);
+
+					$logging->setup(
+						$title,
+						$body,
+						$sf_sync_trigger,
+						0,
+						$status
+					);
+
+					continue;
 				}
 			} elseif ( $sf_sync_trigger === $this->mappings->sync_sf_delete ) {
 				// this is a deletion. don't deal with parameters.

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -215,7 +215,7 @@ class Object_Sync_Sf_Salesforce_Push {
 		if ( isset( $trigger ) ) {
 			$results = $this->salesforce_push_object_crud( $object_type, $object, $trigger, true );
 			foreach ( $results as $result ) {
-				if ( 'success' === $result['status'] ) {
+				if ( isset( $result['status'] ) && 'success' === $result['status'] ) {
 					if ( 'POST' === $http_method || 'PUT' === $http_method ) {
 						$code = '201';
 					} elseif ( 'DELETE' === $http_method ) {
@@ -993,7 +993,7 @@ class Object_Sync_Sf_Salesforce_Push {
 				// this one is not new.
 				$body .= sprintf(
 					// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
-					esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ),
+					'<p>' . esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ) . '</p>',
 					absint( $mapping_object['id'] ),
 					esc_attr( $mapping_object['wordpress_object'] ),
 					esc_attr( $mapping_object['wordpress_id'] ),
@@ -1003,7 +1003,7 @@ class Object_Sync_Sf_Salesforce_Push {
 				// this one is new.
 				$body .= sprintf(
 					// translators: placeholders are: 1) the name of the WordPress object, 2) the ID of the WordPress object, 3) the Salesforce object type.
-					esc_html__( 'The plugin was trying to create a new object map between the WordPress %1$s with ID of %2$s and the Salesforce %3$s object type.', 'object-sync-for-salesforce' ),
+					'<p>' . esc_html__( 'The plugin was trying to push the WordPress %1$s with ID of %2$s to the Salesforce %3$s object type.', 'object-sync-for-salesforce' ) . '</p>',
 					esc_attr( $mapping['wordpress_object'] ),
 					esc_attr( $object[ $wordpress_id_field_name ] ),
 					esc_attr( $mapping['salesforce_object'] )
@@ -1012,7 +1012,7 @@ class Object_Sync_Sf_Salesforce_Push {
 
 			$body .= sprintf(
 				// translators: placeholders are 1) the object's data that was attempted.
-				'<p>' . esc_html__( 'The object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
+				'<p>' . esc_html__( 'The WordPress object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
 				print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			);
 
@@ -1025,7 +1025,7 @@ class Object_Sync_Sf_Salesforce_Push {
 			);
 
 			return;
-		}
+		} // end if params are empty.
 
 		// if there is a prematch WordPress field - ie email - on the fieldmap object.
 		if ( isset( $params['prematch'] ) && is_array( $params['prematch'] ) ) {

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -965,64 +965,66 @@ class Object_Sync_Sf_Salesforce_Push {
 
 			// if the parameters array is empty at this point, we should create a log entry to that effect.
 			// I think it should be a debug message, unless we learn from users that it should be raised to an error.
-			$status = 'debug';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
+			if ( true === $this->debug ) {
+				$status = 'debug';
+				if ( isset( $this->logging ) ) {
+					$logging = $this->logging;
+				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+				}
 
-			$title = sprintf(
-				// translators: %1$s is the log status.
-				esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pushed to Salesforce.', 'object-sync-for-salesforce' ),
-				ucfirst( esc_attr( $status ) )
-			);
-
-			$body = '';
-
-			$body .= sprintf(
-				// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
-				'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
-				absint( $mapping['id'] ),
-				esc_attr( $mapping['wordpress_object'] ),
-				esc_attr( $mapping['salesforce_object'] )
-			);
-
-			// whether it's a new mapping object or not.
-			if ( false === $is_new ) {
-				// this one is not new.
-				$body .= sprintf(
-					// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
-					'<p>' . esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ) . '</p>',
-					absint( $mapping_object['id'] ),
-					esc_attr( $mapping_object['wordpress_object'] ),
-					esc_attr( $mapping_object['wordpress_id'] ),
-					esc_attr( $mapping_object['salesforce_id'] )
+				$title = sprintf(
+					// translators: %1$s is the log status.
+					esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pushed to Salesforce.', 'object-sync-for-salesforce' ),
+					ucfirst( esc_attr( $status ) )
 				);
-			} else {
-				// this one is new.
+
+				$body = '';
+
 				$body .= sprintf(
-					// translators: placeholders are: 1) the name of the WordPress object, 2) the ID of the WordPress object, 3) the Salesforce object type.
-					'<p>' . esc_html__( 'The plugin was trying to push the WordPress %1$s with ID of %2$s to the Salesforce %3$s object type.', 'object-sync-for-salesforce' ) . '</p>',
+					// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
+					'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
+					absint( $mapping['id'] ),
 					esc_attr( $mapping['wordpress_object'] ),
-					esc_attr( $object[ $wordpress_id_field_name ] ),
 					esc_attr( $mapping['salesforce_object'] )
 				);
-			}
 
-			$body .= sprintf(
-				// translators: placeholders are 1) the object's data that was attempted.
-				'<p>' . esc_html__( 'The WordPress object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
-				print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			);
+				// whether it's a new mapping object or not.
+				if ( false === $is_new ) {
+					// this one is not new.
+					$body .= sprintf(
+						// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
+						'<p>' . esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ) . '</p>',
+						absint( $mapping_object['id'] ),
+						esc_attr( $mapping_object['wordpress_object'] ),
+						esc_attr( $mapping_object['wordpress_id'] ),
+						esc_attr( $mapping_object['salesforce_id'] )
+					);
+				} else {
+					// this one is new.
+					$body .= sprintf(
+						// translators: placeholders are: 1) the name of the WordPress object, 2) the ID of the WordPress object, 3) the Salesforce object type.
+						'<p>' . esc_html__( 'The plugin was trying to push the WordPress %1$s with ID of %2$s to the Salesforce %3$s object type.', 'object-sync-for-salesforce' ) . '</p>',
+						esc_attr( $mapping['wordpress_object'] ),
+						esc_attr( $object[ $wordpress_id_field_name ] ),
+						esc_attr( $mapping['salesforce_object'] )
+					);
+				}
 
-			$logging->setup(
-				$title,
-				$body,
-				$sf_sync_trigger,
-				0,
-				$status
-			);
+				$body .= sprintf(
+					// translators: placeholders are 1) the object's data that was attempted.
+					'<p>' . esc_html__( 'The WordPress object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
+					print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				);
+
+				$logging->setup(
+					$title,
+					$body,
+					$sf_sync_trigger,
+					0,
+					$status
+				);
+			} // end debug mode check.
 
 			return;
 		} // end if params are empty.

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -962,6 +962,68 @@ class Object_Sync_Sf_Salesforce_Push {
 
 		// if we don't get any params, there are no fields that should be sent to Salesforce.
 		if ( empty( $params ) ) {
+
+			// if the parameters array is empty at this point, we should create a log entry to that effect.
+			// I think it should be a debug message, unless we learn from users that it should be raised to an error.
+			$status = 'debug';
+			if ( isset( $this->logging ) ) {
+				$logging = $this->logging;
+			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
+				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
+			}
+
+			$title = sprintf(
+				// translators: %1$s is the log status.
+				esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pushed to Salesforce.', 'object-sync-for-salesforce' ),
+				ucfirst( esc_attr( $status ) )
+			);
+
+			$body = '';
+
+			$body .= sprintf(
+				// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
+				'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
+				absint( $mapping['id'] ),
+				esc_attr( $mapping['wordpress_object'] ),
+				esc_attr( $mapping['salesforce_object'] )
+			);
+
+			// whether it's a new mapping object or not.
+			if ( false === $is_new ) {
+				// this one is not new.
+				$body .= sprintf(
+					// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the WordPress object, 4) the ID of the Salesforce object it was trying to map.
+					esc_html__( 'There is an existing object map with ID of %1$s and it is mapped to the WordPress %2$s with ID of %3$s and the Salesforce object with ID of %4$s.', 'object-sync-for-salesforce' ),
+					absint( $mapping_object['id'] ),
+					esc_attr( $mapping_object['wordpress_object'] ),
+					esc_attr( $mapping_object['wordpress_id'] ),
+					esc_attr( $mapping_object['salesforce_id'] )
+				);
+			} else {
+				// this one is new.
+				$body .= sprintf(
+					// translators: placeholders are: 1) the name of the WordPress object, 2) the ID of the WordPress object, 3) the Salesforce object type.
+					esc_html__( 'The plugin was trying to create a new object map between the WordPress %1$s with ID of %2$s and the Salesforce %3$s object type.', 'object-sync-for-salesforce' ),
+					esc_attr( $mapping['wordpress_object'] ),
+					esc_attr( $object[ $wordpress_id_field_name ] ),
+					esc_attr( $mapping['salesforce_object'] )
+				);
+			}
+
+			$body .= sprintf(
+				// translators: placeholders are 1) the object's data that was attempted.
+				'<p>' . esc_html__( 'The object data that was attempted: %1$s', 'object-sync-for-salesforce' ) . '</p>',
+				print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			);
+
+			$logging->setup(
+				$title,
+				$body,
+				$sf_sync_trigger,
+				0,
+				$status
+			);
+
 			return;
 		}
 


### PR DESCRIPTION
## What does this Pull Request do?

This completes work on #362. In a previous version, we added a lock to Salesforce fields that cannot be updated. In this version, we create a debug log entry if the plugin tries to run a push or pull on a specific record, but in the end none of the parameters can be saved.

## How do I test this Pull Request?

- turn on debug mode/logging
- map only Salesforce fields that are not updateable
- try to update them