### PR TITLE
Add a filter to allow developers to edit the whole SOQL string. Thanks to WordPress user @jellypixel.

### DIFF
--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -338,11 +338,28 @@ class Object_Sync_Sf_Salesforce_Pull {
 				}
 			}
 
+			// run the __toString method to convert the SOQL query object to a string.
+			$soql_string = (string) $soql;
+
+			// add a filter here to modify the query once it's a string.
+			// Hook to allow other plugins to modify the SOQL query before it is sent to Salesforce.
+			$soql_string = apply_filters( $this->option_prefix . 'pull_query_string_modify', $soql_string, $soql, $type, $salesforce_mapping, $mapped_fields );
+
+			// quick example to change the order to descending once the query is already a string.
+			/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			add_filter( 'object_sync_for_salesforce_pull_query_string_modify', 'change_pull_query', 10, 5 );
+			// can always reduce this number if all the arguments are not necessary
+			function change_pull_query_string( $soql_string, $soql, $type, $salesforce_mapping, $mapped_fields ) {
+				$soql_string = str_replace( 'ASC', 'DESC', $soql_string);
+				return $soql_string;
+			}
+			*/
+
 			// Execute query
 			// have to cast it to string to make sure it uses the magic method
 			// we don't want to cache this because timestamps.
 			$results = $sfapi->query(
-				(string) $soql,
+				$soql_string,
 				$query_options
 			);
 

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -343,13 +343,13 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			// add a filter here to modify the query once it's a string.
 			// Hook to allow other plugins to modify the SOQL query before it is sent to Salesforce.
-			$soql_string = apply_filters( $this->option_prefix . 'pull_query_string_modify', $soql_string, $soql, $type, $salesforce_mapping, $mapped_fields );
+			$soql_string = apply_filters( $this->option_prefix . 'pull_query_string_modify', $soql_string, $soql, $type, $salesforce_mapping );
 
 			// quick example to change the order to descending once the query is already a string.
 			/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-			add_filter( 'object_sync_for_salesforce_pull_query_string_modify', 'change_pull_query', 10, 5 );
+			add_filter( 'object_sync_for_salesforce_pull_query_string_modify', 'change_pull_query', 10, 4 );
 			// can always reduce this number if all the arguments are not necessary
-			function change_pull_query_string( $soql_string, $soql, $type, $salesforce_mapping, $mapped_fields ) {
+			function change_pull_query_string( $soql_string, $soql, $type, $salesforce_mapping ) {
 				$soql_string = str_replace( 'ASC', 'DESC', $soql_string);
 				return $soql_string;
 			}

--- a/docs/all-developer-hooks.md
+++ b/docs/all-developer-hooks.md
@@ -17,9 +17,13 @@ This page lists all developer hooks available in this plugin, with links to wher
     - code: [classes/class-object-sync-sf-salesforce-push.php](../classes/class-object-sync-sf-salesforce-push.php)
     - documentation: [extending sync allowed](extending-sync-allowed.md#push)
 - `object_sync_for_salesforce_pull_query_modify`:
-    - description: modify the Salesforce query (SOQL) before it is sent to Salesforce to pull records.
+    - description: modify the Salesforce query (SOQL) **object** before it is sent to Salesforce to pull records.
     - code: [classes/class-object-sync-sf-salesforce-pull.php](../classes/class-object-sync-sf-salesforce-pull.php)
-    - documentation: [extending pull](extending-pull.md)
+    - documentation: [extending pull](extending-pull.md#soql-object)
+- `object_sync_for_salesforce_pull_query_string_modify`:
+    - description: modify the Salesforce query (SOQL) **string** before it is sent to Salesforce to pull records.
+    - code: [classes/class-object-sync-sf-salesforce-pull.php](../classes/class-object-sync-sf-salesforce-pull.php)
+    - documentation: [extending pull](extending-pull.md#soql-string)
 - `object_sync_for_salesforce_pull_object_allowed`:
     - description: prevent a pull per-mapping.
     - code: [classes/class-object-sync-sf-salesforce-pull.php](../classes/class-object-sync-sf-salesforce-pull.php)

--- a/docs/extending-pull.md
+++ b/docs/extending-pull.md
@@ -53,14 +53,12 @@ The result of this filter is not processed by the plugin before it is sent to th
 *   Salesforce object type
 * @param array $salesforce_mapping
 *   The map between the WordPress and Salesforce object types
-* @param array $mapped_fields
-*   The fields that are mapped between these objects
 * @return string $soql_string
 *   The SOQL query string
 */
-add_filter( 'object_sync_for_salesforce_pull_query_string_modify', 'change_pull_query_string', 10, 5 );
+add_filter( 'object_sync_for_salesforce_pull_query_string_modify', 'change_pull_query_string', 10, 4 );
 // can always reduce this number if all the arguments are not necessary
-function change_pull_query_string( $soql_string, $soql, $type, $salesforce_mapping, $mapped_fields ) {
+function change_pull_query_string( $soql_string, $soql, $type, $salesforce_mapping ) {
 	$soql_string = str_replace( 'ASC', 'DESC', $soql_string);
 	return $soql_string;
 }

--- a/docs/extending-pull.md
+++ b/docs/extending-pull.md
@@ -1,10 +1,12 @@
 # Extending the Salesforce Pull
 
-When the plugin makes a call to the Salesforce API, it runs a SOQL query using a SOQL query object. Developers can modify this query before it runs.
+## SOQL Object
 
-## Hook
+When the plugin makes a call to the Salesforce API, it runs a SOQL query using a SOQL query object. Developers can modify this query object before it runs.
 
-`object_sync_for_salesforce_pull_query_modify` allows you to change the SOQL query before it is sent to Salesforce.
+### Hook
+
+`object_sync_for_salesforce_pull_query_modify` allows you to change the SOQL query object before it is sent to Salesforce.
 
 ```php
 /**
@@ -26,5 +28,40 @@ add_filter( 'object_sync_for_salesforce_pull_query_modify', 'change_pull_query',
 function change_pull_query( $soql, $type, $salesforce_mapping, $mapped_fields ) {
 	$soql->order = 'DESC';
 	return $soql;
+}
+```
+
+## SOQL String
+
+Before the plugin makes a call to the Salesforce API, it converts the SOQL query to a string. Developers can modify this query string, giving them full control of the query before it runs.
+
+The result of this filter is not processed by the plugin before it is sent to the Salesforce API, so make sure the query has no errors before using it.
+
+### Hook
+
+`object_sync_for_salesforce_pull_query_string_modify` allows you to change the SOQL query string before it is sent to Salesforce.
+
+```php
+/**
+// Example to change the order to descending
+*
+* @param string $soql_string
+*   The SOQL query string
+* @param object $soql
+*   The SOQL query object
+* @param string $object_type
+*   Salesforce object type
+* @param array $salesforce_mapping
+*   The map between the WordPress and Salesforce object types
+* @param array $mapped_fields
+*   The fields that are mapped between these objects
+* @return string $soql_string
+*   The SOQL query string
+*/
+add_filter( 'object_sync_for_salesforce_pull_query_string_modify', 'change_pull_query_string', 10, 5 );
+// can always reduce this number if all the arguments are not necessary
+function change_pull_query_string( $soql_string, $soql, $type, $salesforce_mapping, $mapped_fields ) {
+	$soql_string = str_replace( 'ASC', 'DESC', $soql_string);
+	return $soql_string;
 }
 ```


### PR DESCRIPTION
## What does this Pull Request do?

This adds a new filter for developers, `object_sync_for_salesforce_pull_query_string_modify`, which allows them to modify the entire SOQL string by hand before it is sent to the Salesforce API. This fixes #428.

## How do I test this Pull Request?

- write a SOQL string query that works and use it in a plugin or theme
