### PR TITLE
Change the default Salesforce REST API version to 53.0.

### DIFF
--- a/object-sync-for-salesforce.php
+++ b/object-sync-for-salesforce.php
@@ -43,7 +43,7 @@ define( 'OBJECT_SYNC_SF_VERSION', '2.1.0' );
  * @since 2.0.0
  * @var string
  */
-define( 'OBJECT_SYNC_SF_DEFAULT_API_VERSION', '52.0' );
+define( 'OBJECT_SYNC_SF_DEFAULT_API_VERSION', '53.0' );
 
 // Load the autoloader.
 require_once 'lib/autoloader.php';


### PR DESCRIPTION
## What does this Pull Request do?

When the plugin is newly installed, it suggests a default version of the Salesforce REST API. This updates that value to 53.0, the current version.
