### PR TITLE
As part of the work to support multiple fieldmaps on the same Salesforce object type, object maps need to be loaded with information about the fieldmap.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ Changelog
 	* Maintenance: Update URLs in the documentation that point to plugin PHP files to match their v2.0.0 filenames.
 	* Maintenance: Create a log entry if the plugin tries to sync a record but no parameters are eligible. Thanks to WordPress user @OfficeBureau for the request.
 	* Developers: Add a filter to allow developers to edit the whole SOQL string before it is sent to Salesforce. Thanks to WordPress user @JellyPixel for the request.
+	* Developers: the `load_all_by_salesforce` method has been deprecated in favor of `load_object_maps_by_salesforce_id`, which can receive new (optional) data. `load_all_by_salesforce` will likely be removed in a future 3.0.0 version.
 
 * 2.0.3 (2021-09-10)
 	* Bug fix: Fix missing Record Type when pulled from Salesforce. Thanks to GitHub user @timnolte for the report.

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -899,7 +899,7 @@ class Object_Sync_Sf_Mapping {
 	 * Returns Salesforce object mappings for a given Salesforce object.
 	 *
 	 * @param string $salesforce_id Type of object to load.
-	 * @param array $fieldmap the fieldmap this object map works with.
+	 * @param array  $fieldmap the fieldmap this object map works with.
 	 * @param bool   $reset Whether or not the cache should be cleared and fetch from current data.
 	 *
 	 * @return array $maps all the object maps that match the Salesforce Id

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -686,7 +686,7 @@ class Object_Sync_Sf_Mapping {
 			return $this->wpdb->insert_id;
 		} elseif ( false !== strpos( $this->wpdb->last_error, 'Duplicate entry' ) ) {
 			// this error should never happen now, I think. But let's watch and see.
-			$mapping = $this->load_all_by_salesforce( $data['salesforce_id'] )[0];
+			$mapping = $this->load_object_maps_by_salesforce_id( $data['salesforce_id'] )[0];
 			$id      = $mapping['id'];
 			$status  = 'error';
 			if ( isset( $this->logging ) ) {
@@ -899,17 +899,34 @@ class Object_Sync_Sf_Mapping {
 	 * Returns Salesforce object mappings for a given Salesforce object.
 	 *
 	 * @param string $salesforce_id Type of object to load.
+	 * @param array $fieldmap the fieldmap this object map works with.
 	 * @param bool   $reset Whether or not the cache should be cleared and fetch from current data.
 	 *
 	 * @return array $maps all the object maps that match the Salesforce Id
 	 */
-	public function load_all_by_salesforce( $salesforce_id, $reset = false ) {
+	public function load_object_maps_by_salesforce_id( $salesforce_id, $fieldmap = array(), $reset = false ) {
 		$conditions = array(
 			'salesforce_id' => $salesforce_id,
 		);
-
+		if ( is_array( $fieldmap ) && ! empty( $fieldmap ) ) {
+			$conditions['wordpress_object'] = $fieldmap['wordpress_object'];
+		}
 		$maps = $this->get_all_object_maps( $conditions, $reset );
 
+		return $maps;
+	}
+
+	/**
+	 * Returns Salesforce object mappings for a given Salesforce object.
+	 *
+	 * @param string $salesforce_id Type of object to load.
+	 * @param bool   $reset Whether or not the cache should be cleared and fetch from current data.
+	 *
+	 * @return array $maps all the object maps that match the Salesforce Id
+	 * @deprecated since 2.1.0. Will be removed in 3.0.0.
+	 */
+	public function load_all_by_salesforce( $salesforce_id, $reset = false ) {
+		$maps = $this->load_object_maps_by_salesforce( $salesforce_id, array(), $reset );
 		return $maps;
 	}
 

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -1057,7 +1057,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		if ( isset( $merged_record['Id'] ) && true === filter_var( $merged_record['sf:IsDeleted'], FILTER_VALIDATE_BOOLEAN ) && '' !== $merged_record['sf:MasterRecordId'] ) {
 			$previous_sf_id  = $merged_record['Id'];
 			$new_sf_id       = $merged_record['sf:MasterRecordId'];
-			$mapping_objects = $this->mappings->load_all_by_salesforce( $previous_sf_id );
+			$mapping_objects = $this->mappings->load_object_maps_by_salesforce_id( $previous_sf_id );
 			foreach ( $mapping_objects as $mapping_object ) {
 				$wordpress_type                  = $mapping_object['wordpress_object'];
 				$wordpress_id                    = $mapping_object['wordpress_id'];
@@ -1362,7 +1362,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			// this returns the row that maps an individual Salesforce row to an individual WordPress row.
 			if ( isset( $object['Id'] ) ) {
-				$mapping_objects = $this->mappings->load_all_by_salesforce( $object['Id'] );
+				$mapping_objects = $this->mappings->load_object_maps_by_salesforce_id( $object['Id'], $salesforce_mapping );
 			} else {
 				// if we don't have a Salesforce object id, we've got no business doing stuff in WordPress.
 				$status = 'error';
@@ -2444,7 +2444,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		// if the current fieldmap does not allow create, we need to check if there is an object map for the Salesforce object Id. if not, set pull_allowed to false.
 		if ( ! in_array( $this->mappings->sync_sf_create, $map_sync_triggers, true ) ) {
-			$object_map = $this->mappings->load_all_by_salesforce( $object['Id'] );
+			$object_map = $this->mappings->load_object_maps_by_salesforce_id( $object['Id'], $salesforce_mapping );
 			if ( empty( $object_map ) ) {
 				$pull_allowed = false;
 			}

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -807,7 +807,7 @@ class Object_Sync_Sf_Salesforce_Push {
 			if ( isset( $mapping_object['id'] ) ) {
 				$op = 'Delete';
 
-				$mapping_objects = $this->mappings->load_all_by_salesforce( $mapping_object['salesforce_id'] );
+				$mapping_objects = $this->mappings->load_object_maps_by_salesforce_id( $mapping_object['salesforce_id'], $mapping );
 
 				// only delete if there are no additional mapping objects for this record.
 				if ( 1 === count( $mapping_objects ) ) {


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #437 by adding a new method, `load_object_maps_by_salesforce`, that takes the fieldmap as a parameter so we can specify the WordPress object type when loading object maps that are tied to a Salesforce ID.

This also deprecates `load_all_by_salesforce`.

## How do I test this Pull Request?

Same steps as #420.