### PR TITLE
Remove arrow functions that are only supported in PHP 7.4. Thanks to WordPress users @ofrayechiel and @trohrer for the report.

### DIFF
--- a/classes/class-object-sync-sf-pull-options.php
+++ b/classes/class-object-sync-sf-pull-options.php
@@ -64,17 +64,13 @@ class Object_Sync_Sf_Pull_Options {
 	 */
 	private function generate_option_key( $params, $legacy = false ) {
 		array_unshift( $params, substr( $this->option_prefix, 0, -1 ), $this->direction ); // add the prefixes.
-		// remove null and empty values. different method for php 7.4 and higher.
-		if ( version_compare( PHP_VERSION, '7.4.0', '>=' ) ) {
-			$params = array_filter( $params, fn( $value ) => ! is_null( $value ) && '' !== $value );
-		} else {
-			$params = array_filter(
-				$params,
-				function( $value ) {
-					return ! is_null( $value ) && '' !== $value;
-				}
-			);
-		}
+		// remove null and empty values.
+		$params = array_filter(
+			$params,
+			function( $value ) {
+				return ! is_null( $value ) && '' !== $value;
+			}
+		);
 
 		// legacy keys don't have a fieldmap.
 		if ( true === $legacy && isset( $params['fieldmap_id'] ) ) {

--- a/classes/class-object-sync-sf-sync-transients.php
+++ b/classes/class-object-sync-sf-sync-transients.php
@@ -54,17 +54,13 @@ class Object_Sync_Sf_Sync_Transients {
 	 */
 	private function generate_transient_key( $params, $legacy = false ) {
 		array_unshift( $params, substr( $this->option_prefix, 0, -1 ) ); // add the prefixes.
-		// remove null and empty values. different method for php 7.4 and higher.
-		if ( version_compare( PHP_VERSION, '7.4.0', '>=' ) ) {
-			$params = array_filter( $params, fn( $value ) => ! is_null( $value ) && '' !== $value );
-		} else {
-			$params = array_filter(
-				$params,
-				function( $value ) {
-					return ! is_null( $value ) && '' !== $value;
-				}
-			);
-		}
+		// remove null and empty values.
+		$params = array_filter(
+			$params,
+			function( $value ) {
+				return ! is_null( $value ) && '' !== $value;
+			}
+		);
 
 		// legacy keys don't have a fieldmap.
 		if ( true === $legacy && isset( $params['fieldmap_id'] ) ) {


### PR DESCRIPTION
## What does this Pull Request do?

This removes the arrow functions because, as stated by @trohrer:
> Unfortunately ofrayechiel is correct. When Zend added arrow functions in 7.4, it now throws errors in the syntax parser of existing, older versions of PHP.

## How do I test this Pull Request?

- run PHP version 7.3 or earlier