### PR TITLE
When creating a new fieldmap, set a default status of "active" to prevent a PHP notice.

### DIFF
--- a/templates/admin/fieldmaps-add-edit-clone.php
+++ b/templates/admin/fieldmaps-add-edit-clone.php
@@ -593,6 +593,9 @@
 				foreach ( $fieldmap_statuses as $key => $value ) :
 					if ( '' !== $value ) :
 						$selected = '';
+						if ( ! isset( $fieldmap_status ) ) {
+							$fieldmap_status = 'active';
+						}
 						if ( $fieldmap_status === $key ) {
 							$selected = ' selected';
 						}


### PR DESCRIPTION
## What does this Pull Request do?

In addition to preventing the PHP notice in the server logs, this matches the normal pattern for this template. Normally those default values are empty, but in this case it makes sense for the default to have a value. This fixes #456.

## How do I test this Pull Request?

- create a new fieldmap
- see that the error logs aren't affected.