### PR TITLE
Remove the requirement to set the Salesforce REST API version from the interface in favor of a plugin-wide setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ All versions of this plugin are listed in the [releases](https://github.com/Minn
 = 2.1.2 =
 Apologies for the buggy release of version 2.1.0 and 2.1.1. I'm hopeful that these issues are resolved in 2.1.2.
 
+= 2.2.0 =
+In version 2.2.0, the Salesforce REST API version is no longer configured in the plugin settings. For backward-compatibility, the plugin will continue to use stored values until version 3.0.0 unless they are the same as the plugin's default value. In 2.2.0, this is version 55.0.
+
 </only:wp -->
 
 <!-- only:github/ -->

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* 2.2.0 ()
+	* Feature: the requirement to set the REST API version that the plugin uses to send requests to Salesforce has been removed from the plugin interface in favor of storing this value in the plugin (this plugin version uses API version 55.0). For most users this is an improvement; it removes the potential for old API versions to cause problems with new functionality, and removes the potential for users to unintentionally use API versions that are no longer active. **Note**: You can delete the `object_sync_for_salesforce_api_version` field from the `wp_options` table on your own, set it to 55.0 so the plugin can delete it, or wait until version 3.0.0 is released for that value to be deleted.
+	* Developers: Add a `object_sync_for_salesforce_modify_salesforce_api_version` filter to allow developers to edit the REST API version for Salesforce API requests. See [the documentation](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/docs/adding-settings.md#change-the-rest-api-version-for-salesforce-requests) for how to use it.
+
 * 2.1.2 (2022-02-04)
 	* Bug fix: Remove arrow functions that are only supported in PHP 7.4 and cannot be backfilled. Thanks to WordPress users @ofrayechiel and @trohrer for the report.
 	* Bug fix: Resolve a (widely reported) problem in 2.1.x versions, where pushing an update from a Salesforce record can cause the plugin to incorrectly detect the record as pulling, preventing the record from pushing.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* 2.2.0 ()
+	* Feature: the requirement to set the REST API version that the plugin uses to send requests to Salesforce has been removed from the plugin interface in favor of storing this value in the plugin (this plugin version uses API version 55.0). For most users this is an improvement; it removes the potential for old API versions to cause problems with new functionality, and removes the potential for users to unintentionally use API versions that are no longer active. **Note**: You can delete the `object_sync_for_salesforce_api_version` field from the `wp_options` table on your own, set it to 55.0 so the plugin can delete it, or wait until version 3.0.0 is released for that value to be deleted.
+	* Developers: Add a `object_sync_for_salesforce_modify_salesforce_api_version` filter to allow developers to edit the REST API version for Salesforce API requests. See [the documentation](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/docs/adding-settings.md#change-the-rest-api-version-for-salesforce-requests) for how to use it.
+
 * 2.1.2 (2022-02-04)
 	* Bug fix: Remove arrow functions that are only supported in PHP 7.4 and cannot be backfilled. Thanks to WordPress users @ofrayechiel and @trohrer for the report.
 	* Bug fix: Resolve a (widely reported) problem in 2.1.x versions, where pushing an update from a Salesforce record can cause the plugin to incorrectly detect the record as pulling, preventing the record from pushing.

--- a/classes/class-object-sync-salesforce.php
+++ b/classes/class-object-sync-salesforce.php
@@ -306,40 +306,66 @@ class Object_Sync_Salesforce {
 	 * As of version 2.2.0, this is set by the plugin and is not configurable in the interface, though it can be overridden by developer hook.
 	 * Until version 3.0, this value will be overridden by pre-existing settings.
 	 *
-	 * @return string $sf_api_version the active Salesforce version.
+	 * @return array $sf_api_version_data what we know about the API version that is in use.
 	 */
 	public function get_salesforce_api_version() {
-		$sf_api_version = OBJECT_SYNC_SF_DEFAULT_API_VERSION;
-		$sf_api_version = $this->check_deprecated_salesforce_api_version( $sf_api_version );
-		// developers can modify the active API version. if supplied, this takes priority.
-		$sf_api_version = apply_filters( $this->option_prefix . 'modify_salesforce_api_version', $sf_api_version );
+		$sf_api_version      = OBJECT_SYNC_SF_DEFAULT_API_VERSION;
+		$sf_api_version_data = array(
+			'rest_api_version'        => $sf_api_version,
+			'using_deprecated_option' => false,
+			'using_developer_filter'  => false,
+		);
 
+		// check for a deprecated version. if provided, use it.
+		$deprecated_api_version = $this->check_deprecated_salesforce_api_version( $sf_api_version );
+		if ( '' !== $deprecated_api_version ) {
+			$sf_api_version_data['rest_api_version']        = $deprecated_api_version;
+			$sf_api_version_data['using_deprecated_option'] = true;
+		}
+
+		// developers can modify the active API version. if provided, this takes priority.
+		$developer_api_version = apply_filters( $this->option_prefix . 'modify_salesforce_api_version', $sf_api_version );
+		if ( $developer_api_version !== $sf_api_version ) {
+			$sf_api_version_data['rest_api_version']       = $developer_api_version;
+			$sf_api_version_data['using_developer_filter'] = true;
+		}
 		/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-		 * example to modify the array of classes by adding one and removing one
+		 * example to change the REST API version by filter
 		 * add_filter( 'object_sync_for_salesforce_modify_salesforce_api_version', 'modify_salesforce_api_version', 10, 1 );
 		 * function modify_salesforce_api_version( $sf_api_version ) {
 		 * 	$sf_api_version = '52.0';
 		 * 	return $sf_api_version;
 		 * }
 		*/
-		return $sf_api_version;
+
+		// return array that includes: 1) what version, 2) if it is a deprecated version, 3) if it is developer overridden.
+		return $sf_api_version_data;
 	}
 
 	/**
-	 * Check deprecated methods for a Salesforce API version. If one is set, trigger a notice.
+	 * Check deprecated methods for a Salesforce API version.
 	 *
 	 * @param string $sf_api_version the active Salesforce version.
-	 * @return string $sf_api_version the active Salesforce version.
+	 * @return string $deprecated_api_version the deprecated Salesforce version, if it exists.
+	 * @deprecated and will be removed in version 3.0.
 	 */
 	private function check_deprecated_salesforce_api_version( $sf_api_version ) {
-		$deprecated_api_version = defined( 'OBJECT_SYNC_SF_SALESFORCE_API_VERSION' ) ? OBJECT_SYNC_SF_SALESFORCE_API_VERSION : get_option( $this->option_prefix . 'api_version', '' );
-		if ( '' !== $deprecated_api_version && $sf_api_version !== $deprecated_api_version ) {
-			// trigger a notice here.
-			$sf_api_version = $deprecated_api_version;
-		} else {
-			delete_option( $this->option_prefix . 'api_version' );
+		$deprecated_api_version = defined( 'OBJECT_SYNC_SF_SALESFORCE_API_VERSION' ) ? OBJECT_SYNC_SF_SALESFORCE_API_VERSION : '';
+		// if the constant exists.
+		if ( '' === $deprecated_api_version ) {
+			$deprecated_option_key = $this->option_prefix . 'api_version';
+			$deprecated_api_option = get_option( $deprecated_option_key, 'not-exists' );
+			// if the option exists (the value in the database is not not-exists).
+			if ( 'not-exists' !== $deprecated_api_option ) {
+				$deprecated_api_version = $deprecated_api_option;
+				// if it exists, and is set to "" or exists and is is the same as the default version, just delete it.
+				if ( '' === $deprecated_api_version || $deprecated_api_version === $sf_api_version ) {
+					$deprecated_api_version = '';
+					delete_option( $deprecated_option_key );
+				}
+			}
 		}
-		return $sf_api_version;
+		return $deprecated_api_version;
 	}
 
 	/**
@@ -350,26 +376,24 @@ class Object_Sync_Salesforce {
 	 */
 	private function get_login_credentials() {
 
-		$consumer_key       = defined( 'OBJECT_SYNC_SF_SALESFORCE_CONSUMER_KEY' ) ? OBJECT_SYNC_SF_SALESFORCE_CONSUMER_KEY : get_option( $this->option_prefix . 'consumer_key', '' );
-		$consumer_secret    = defined( 'OBJECT_SYNC_SF_SALESFORCE_CONSUMER_SECRET' ) ? OBJECT_SYNC_SF_SALESFORCE_CONSUMER_SECRET : get_option( $this->option_prefix . 'consumer_secret', '' );
-		$callback_url       = defined( 'OBJECT_SYNC_SF_SALESFORCE_CALLBACK_URL' ) ? OBJECT_SYNC_SF_SALESFORCE_CALLBACK_URL : get_option( $this->option_prefix . 'callback_url', '' );
-		$login_base_url     = defined( 'OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL' ) ? OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL : get_option( $this->option_prefix . 'login_base_url', '' );
-		$authorize_url_path = defined( 'OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH' ) ? OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH : get_option( $this->option_prefix . 'authorize_url_path', '' );
-		$token_url_path     = defined( 'OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH' ) ? OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH : get_option( $this->option_prefix . 'token_url_path', '' );
-		$api_version        = $this->get_salesforce_api_version();
+		$consumer_key        = defined( 'OBJECT_SYNC_SF_SALESFORCE_CONSUMER_KEY' ) ? OBJECT_SYNC_SF_SALESFORCE_CONSUMER_KEY : get_option( $this->option_prefix . 'consumer_key', '' );
+		$consumer_secret     = defined( 'OBJECT_SYNC_SF_SALESFORCE_CONSUMER_SECRET' ) ? OBJECT_SYNC_SF_SALESFORCE_CONSUMER_SECRET : get_option( $this->option_prefix . 'consumer_secret', '' );
+		$callback_url        = defined( 'OBJECT_SYNC_SF_SALESFORCE_CALLBACK_URL' ) ? OBJECT_SYNC_SF_SALESFORCE_CALLBACK_URL : get_option( $this->option_prefix . 'callback_url', '' );
+		$login_base_url      = defined( 'OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL' ) ? OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL : get_option( $this->option_prefix . 'login_base_url', '' );
+		$authorize_url_path  = defined( 'OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH' ) ? OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH : get_option( $this->option_prefix . 'authorize_url_path', '' );
+		$token_url_path      = defined( 'OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH' ) ? OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH : get_option( $this->option_prefix . 'token_url_path', '' );
+		$sf_api_version_data = $this->get_salesforce_api_version();
 
 		$login_credentials = array(
-			'consumer_key'     => $consumer_key,
-			'consumer_secret'  => $consumer_secret,
-			'callback_url'     => $callback_url,
-			'login_url'        => $login_base_url,
-			'authorize_path'   => $authorize_url_path,
-			'token_path'       => $token_url_path,
-			'rest_api_version' => $api_version,
+			'consumer_key'    => $consumer_key,
+			'consumer_secret' => $consumer_secret,
+			'callback_url'    => $callback_url,
+			'login_url'       => $login_base_url,
+			'authorize_path'  => $authorize_url_path,
+			'token_path'      => $token_url_path,
 		);
-
+		$login_credentials = array_merge( $login_credentials, $sf_api_version_data );
 		return $login_credentials;
-
 	}
 
 	/**

--- a/classes/class-object-sync-salesforce.php
+++ b/classes/class-object-sync-salesforce.php
@@ -302,6 +302,47 @@ class Object_Sync_Salesforce {
 	}
 
 	/**
+	 * Set the Salesforce API version.
+	 * As of version 2.2.0, this is set by the plugin and is not configurable in the interface, though it can be overridden by developer hook.
+	 * Until version 3.0, this value will be overridden by pre-existing settings.
+	 *
+	 * @return string $sf_api_version the active Salesforce version.
+	 */
+	public function get_salesforce_api_version() {
+		$sf_api_version = OBJECT_SYNC_SF_DEFAULT_API_VERSION;
+		$sf_api_version = $this->check_deprecated_salesforce_api_version( $sf_api_version );
+		// developers can modify the active API version. if supplied, this takes priority.
+		$sf_api_version = apply_filters( $this->option_prefix . 'modify_salesforce_api_version', $sf_api_version );
+
+		/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+		 * example to modify the array of classes by adding one and removing one
+		 * add_filter( 'object_sync_for_salesforce_modify_salesforce_api_version', 'modify_salesforce_api_version', 10, 1 );
+		 * function modify_salesforce_api_version( $sf_api_version ) {
+		 * 	$sf_api_version = '52.0';
+		 * 	return $sf_api_version;
+		 * }
+		*/
+		return $sf_api_version;
+	}
+
+	/**
+	 * Check deprecated methods for a Salesforce API version. If one is set, trigger a notice.
+	 *
+	 * @param string $sf_api_version the active Salesforce version.
+	 * @return string $sf_api_version the active Salesforce version.
+	 */
+	private function check_deprecated_salesforce_api_version( $sf_api_version ) {
+		$deprecated_api_version = defined( 'OBJECT_SYNC_SF_SALESFORCE_API_VERSION' ) ? OBJECT_SYNC_SF_SALESFORCE_API_VERSION : get_option( $this->option_prefix . 'api_version', '' );
+		if ( '' !== $deprecated_api_version && $sf_api_version !== $deprecated_api_version ) {
+			// trigger a notice here.
+			$sf_api_version = $deprecated_api_version;
+		} else {
+			delete_option( $this->option_prefix . 'api_version' );
+		}
+		return $sf_api_version;
+	}
+
+	/**
 	 * Get the pre-login Salesforce credentials.
 	 * These depend on the plugin's settings or constants defined in wp-config.php.
 	 *
@@ -315,7 +356,7 @@ class Object_Sync_Salesforce {
 		$login_base_url     = defined( 'OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL' ) ? OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL : get_option( $this->option_prefix . 'login_base_url', '' );
 		$authorize_url_path = defined( 'OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH' ) ? OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH : get_option( $this->option_prefix . 'authorize_url_path', '' );
 		$token_url_path     = defined( 'OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH' ) ? OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH : get_option( $this->option_prefix . 'token_url_path', '' );
-		$api_version        = defined( 'OBJECT_SYNC_SF_SALESFORCE_API_VERSION' ) ? OBJECT_SYNC_SF_SALESFORCE_API_VERSION : get_option( $this->option_prefix . 'api_version', '' );
+		$api_version        = $this->get_salesforce_api_version();
 
 		$login_credentials = array(
 			'consumer_key'     => $consumer_key,

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1463,10 +1463,11 @@ class Object_Sync_Sf_Admin {
 				'condition'   => ( isset( $this->login_credentials['using_deprecated_option'] ) && true === $this->login_credentials['using_deprecated_option'] ),
 				'message'     => sprintf(
 					// translators: 1) is the version number of the Salesforce REST API, 2) is the option key for where the deprecated version is stored, and 3) is the prefixed options table name.
-					esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, or wait until that release.', 'object-sync-for-salesforce' ),
+					esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, set it to %4$s so the plugin can delete it, or wait until that release.', 'object-sync-for-salesforce' ),
 					esc_attr( $this->login_credentials['rest_api_version'] ),
 					'<code>' . esc_attr( $this->option_prefix . 'api_version' ) . '</code>',
-					'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>'
+					'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>',
+					'<code>' . esc_attr( OBJECT_SYNC_SF_DEFAULT_API_VERSION ) . '</code>'
 				),
 				'type'        => 'error',
 				'dismissible' => true,

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1459,6 +1459,18 @@ class Object_Sync_Sf_Admin {
 				'type'        => 'error',
 				'dismissible' => false,
 			),
+			'deprecated_api_version'  => array(
+				'condition'   => ( isset( $this->login_credentials['using_deprecated_option'] ) && true === $this->login_credentials['using_deprecated_option'] ),
+				'message'     => sprintf(
+					// translators: 1) is the version number of the Salesforce REST API, 2) is the option key for where the deprecated version is stored, and 3) is the prefixed options table name.
+					esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, or wait until that release.', 'object-sync-for-salesforce' ),
+					esc_attr( $this->login_credentials['rest_api_version'] ),
+					'<code>' . esc_attr( $this->option_prefix . 'api_version' ) . '</code>',
+					'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>'
+				),
+				'type'        => 'error',
+				'dismissible' => true,
+			),
 			'fieldmap'                => array(
 				'condition'   => isset( $get_data['transient'] ),
 				'message'     => esc_html__( 'Errors kept this fieldmap from being saved.', 'object-sync-for-salesforce' ),

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -229,8 +229,8 @@ class Object_Sync_Sf_Admin {
 
 		// set the Salesforce API version.
 		// as of version 2.2.0, this is set by the plugin and is not configurable in the interface.
-		// until version 3.0, this value will use a pre-existing setting if one exists.
-		$this->default_api_version = object_sync_for_salesforce()->get_salesforce_api_version();
+		// this class variable will be removed in 3.0.0.
+		$this->default_api_version = $this->login_credentials['rest_api_version'];
 
 		$this->sfwp_transients          = object_sync_for_salesforce()->wordpress->sfwp_transients;
 		$this->admin_settings_url_param = 'object-sync-salesforce-admin';

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -174,7 +174,7 @@ class Object_Sync_Sf_Admin {
 	 * been authenticated with Salesforce.
 	 *
 	 * @var string
-	 * @deprecated as of 2.2.0; will be removed in version 3.0.
+	 * @deprecated as of 2.2.0; will be removed in version 3.0. This property will stay until 3.0.0 because it is a public value and it could be accessed by other code.
 	 */
 	public $default_api_version;
 

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -134,6 +134,13 @@ class Object_Sync_Sf_Admin {
 	private $admin_settings_url_param;
 
 	/**
+	 * Data for admin notices
+	 *
+	 * @var array
+	 */
+	public $notices_data;
+
+	/**
 	 * Salesforce access token
 	 *
 	 * @var string
@@ -234,6 +241,7 @@ class Object_Sync_Sf_Admin {
 
 		$this->sfwp_transients          = object_sync_for_salesforce()->wordpress->sfwp_transients;
 		$this->admin_settings_url_param = 'object-sync-salesforce-admin';
+		$this->notices_data             = $this->notices_data();
 
 		// default authorize url path.
 		$this->default_authorize_url_path = '/services/oauth2/authorize';
@@ -265,7 +273,7 @@ class Object_Sync_Sf_Admin {
 		// Settings API forms and notices.
 		add_action( 'admin_menu', array( $this, 'create_admin_menu' ) );
 		add_action( 'admin_init', array( $this, 'salesforce_settings_forms' ) );
-		add_action( 'admin_init', array( $this, 'notices' ) );
+		add_action( 'admin_init', array( $this, 'display_notices' ) );
 		add_action( 'admin_post_post_fieldmap', array( $this, 'prepare_fieldmap_data' ) );
 		add_action( 'admin_post_delete_fieldmap', array( $this, 'delete_fieldmap' ) );
 
@@ -1424,17 +1432,11 @@ class Object_Sync_Sf_Admin {
 	}
 
 	/**
-	 * Create the notices, settings, and conditions by which admin notices should appear
+	 * Create and return the data for notices.
+	 *
+	 * @return array $notices is the array of notices.
 	 */
-	public function notices() {
-
-		// before a notice is displayed, we should make sure we are on a page related to this plugin.
-		if ( ! isset( $_GET['page'] ) || $this->admin_settings_url_param !== $_GET['page'] ) {
-			return;
-		}
-
-		$get_data = filter_input_array( INPUT_GET, FILTER_SANITIZE_STRING );
-
+	public function notices_data() {
 		$notices = array(
 			'permission'              => array(
 				'condition'   => ( false === $this->check_wordpress_admin_permissions() ),
@@ -1515,6 +1517,21 @@ class Object_Sync_Sf_Admin {
 				'dismissible' => true,
 			),
 		);
+		return $notices;
+	}
+
+	/**
+	 * Create the notices, settings, and conditions by which admin notices should appear
+	 */
+	public function display_notices() {
+
+		// before a notice is displayed, we should make sure we are on a page related to this plugin.
+		if ( ! isset( $_GET['page'] ) || $this->admin_settings_url_param !== $_GET['page'] ) {
+			return;
+		}
+
+		$get_data = filter_input_array( INPUT_GET, FILTER_SANITIZE_STRING );
+		$notices  = $this->notices_data();
 
 		foreach ( $notices as $key => $value ) {
 

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -256,6 +256,8 @@ class Object_Sync_Sf_Salesforce {
 	/**
 	 * Get REST API versions available on this Salesforce organization
 	 * This is not an authenticated call, so it would not be a helpful test
+	 *
+	 * @deprecated since version 2.2.0; will be removed in 3.0.0.
 	 */
 	public function get_api_versions() {
 		$options = array(

--- a/docs/adding-settings.md
+++ b/docs/adding-settings.md
@@ -1,6 +1,6 @@
 # Adding settings
 
-Developers can extend the settings interface for this plugin in a couple of ways. This allows you to, for example, add another tab in addition to the defaults: Settings, Authorize, Fieldmaps, Scheduling, and Log Settings.
+Developers can extend the settings interface for this plugin in a couple of ways. This allows you to, for example, add another tab in addition to the defaults: Settings, Authorize, Fieldmaps, Scheduling, and Log Settings. Developers can also override the REST API version that the plugin uses to send requests to Salesforce.
 
 ## Add a settings tab
 
@@ -116,5 +116,25 @@ function add_content( $content_after = null, $tab ) {
         $content_after = '<p>this is an outro.</p>';
     }
     return $content_after;
+}
+```
+
+## Changing settings with code
+
+### Change the REST API version for Salesforce requests
+
+As of version 2.2.0, the requirement to set the REST API version that the plugin uses to send requests to Salesforce has been removed from the plugin interface. For most users this is an improvement; it removes the potential for old API versions to cause problems with new functionality, and removes the potential for users to unintentionally use API versions that are no longer active.
+
+For developers who many rely on version-specific API functionality from Salesforce and are able to deal with potential consequences, the plugin does include a filter with the ability to override the REST API version for all plugin API requests. You might do this if you use custom functionality that depends on an older or newer version of the API than is supported by the plugin.
+
+#### Code example
+
+To override the REST API version, you can use this code:
+
+```php
+add_filter( 'object_sync_for_salesforce_modify_salesforce_api_version', 'modify_salesforce_api_version', 10, 1 );
+function modify_salesforce_api_version( $sf_api_version ) {
+    $sf_api_version = '52.0';
+    return $sf_api_version;
 }
 ```

--- a/docs/all-developer-hooks.md
+++ b/docs/all-developer-hooks.md
@@ -76,6 +76,10 @@ This page lists all developer hooks available in this plugin, with links to wher
     - description: when adding tabs to the Salesforce Settings screen, send additional content to display after the settings form.
     - code: [classes/class-object-sync-sf-admin.php](../classes/class-object-sync-sf-admin.php)
     - documentation: [adding settings](./adding-settings.md#add-content-to-a-tab)
+- `object_sync_for_salesforce_modify_salesforce_api_version`:
+    - description: allow other plugins to change the Salesforce REST API version for API calls that are sent to Salesforce.
+    - code: [classes/class-object-sync-salesforce.php](../classes/class-object-sync-salesforce.php)
+    - documentation: [adding settings](./adding-settings.md#api-version)
 - `object_sync_for_salesforce_modify_schedulable_classes`:
     - description: modify the array of schedulable classes. This is the list of classes that can use the `schedule` class to run a queue of scheduled tasks.
     - code: [classes/class-object-sync-salesforce.php](../classes/class-object-sync-salesforce.php)

--- a/docs/all-developer-hooks.md
+++ b/docs/all-developer-hooks.md
@@ -79,7 +79,7 @@ This page lists all developer hooks available in this plugin, with links to wher
 - `object_sync_for_salesforce_modify_salesforce_api_version`:
     - description: allow other plugins to change the Salesforce REST API version for API calls that are sent to Salesforce.
     - code: [classes/class-object-sync-salesforce.php](../classes/class-object-sync-salesforce.php)
-    - documentation: [adding settings](./adding-settings.md#api-version)
+    - documentation: [adding settings](./adding-settings.md##change-the-rest-api-version-for-salesforce-requests)
 - `object_sync_for_salesforce_modify_schedulable_classes`:
     - description: modify the array of schedulable classes. This is the list of classes that can use the `schedule` class to run a queue of scheduled tasks.
     - code: [classes/class-object-sync-salesforce.php](../classes/class-object-sync-salesforce.php)

--- a/object-sync-for-salesforce.php
+++ b/object-sync-for-salesforce.php
@@ -38,12 +38,12 @@ define( 'OBJECT_SYNC_SF_FILE', __FILE__ );
 define( 'OBJECT_SYNC_SF_VERSION', '2.1.2' );
 
 /**
- * The default Salesforce API version for new installs
+ * The default Salesforce API version, unless it has been overridden by pre-existing option or by developers
  *
  * @since 2.0.0
  * @var string
  */
-define( 'OBJECT_SYNC_SF_DEFAULT_API_VERSION', '53.0' );
+define( 'OBJECT_SYNC_SF_DEFAULT_API_VERSION', '55.0' );
 
 // Load the autoloader.
 require_once 'lib/autoloader.php';

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -10,21 +10,32 @@
 <h3><?php echo esc_html__( 'Salesforce API Connection Status', 'object-sync-for-salesforce' ); ?></h3>
 
 <p>
-	<?php
-	echo sprintf(
-		// translators: placeholder is for the version number of the Salesforce REST API.
-		esc_html__( 'Object Sync for Salesforce is making calls to the Salesforce REST API using version %1$s. ', 'object-sync-for-salesforce' ),
-		esc_html( $this->login_credentials['rest_api_version'] )
-	);
-	?>
 	<?php if ( false === $this->login_credentials['using_deprecated_option'] && false === $this->login_credentials['using_developer_filter'] ) : ?>
 		<?php
-			echo esc_html__( 'This plugin works to keep up to date with the release cycle of API versions from Salesforce. When a new version is released, the plugin will upgrade to that version as soon as possible. If you upgrade the plugin when new releases come out, you will always be on the highest supported version of the Salesforce REST API. Object Sync for Salesforce will not include plugin functionality that depends on a version it does not support, and will ensure that all releases follow this pattern.', 'object-sync-for-salesforce' );
+			echo sprintf(
+				// translators: 1) is the version number of the Salesforce REST API.
+				esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API. This plugin works to keep up to date with the release cycle of API versions from Salesforce. When a new version is released, the plugin will upgrade to that version as soon as possible. If you upgrade the plugin when new releases come out, you will always be on the highest supported version of the Salesforce REST API. Object Sync for Salesforce will not include plugin functionality that depends on a version it does not support.', 'object-sync-for-salesforce' ),
+				esc_attr( $this->login_credentials['rest_api_version'] )
+			);
 		?>
 	<?php elseif ( true === $this->login_credentials['using_deprecated_option'] ) : ?>
-		<?php echo esc_html__( 'This API version is set from a previous version of the plugin, and the plugin functionality of choosing the API version in the interface has been deprecated. In a future release (likely version 3.0.0), the ability to use the REST API version set by the interface will be removed.', 'object-sync-for-salesforce' ); ?>
+		<?php
+			echo sprintf(
+				// translators: 1) is the version number of the Salesforce REST API, 2) is the option key for where the deprecated version is stored, and 3) is the prefixed options table name.
+				esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, or wait until that release.', 'object-sync-for-salesforce' ),
+				esc_attr( $this->login_credentials['rest_api_version'] ),
+				'<code>' . esc_attr( $this->option_prefix . 'api_version' ) . '</code>',
+				'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>'
+			);
+		?>
 	<?php else : ?>
-		<?php echo esc_html__( 'This API version is set with the use of a developer hook.', 'object-sync-for-salesforce' ); ?>
+		<?php
+			echo sprintf(
+				// translators: 1) is the version number of the Salesforce REST API.
+				esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured by developer hook. This value is no longer configurable in the plugin settings, but will continue to support this developer hook. However, use this at your own risk, as it is possible that the Salesforce REST API, or this plugin, will depend on different functionality than other versions.', 'object-sync-for-salesforce' ),
+				esc_attr( $this->login_credentials['rest_api_version'] )
+			);
+		?>
 	<?php endif; ?>
 </p>
 

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -19,16 +19,7 @@
 			);
 		?>
 	<?php elseif ( true === $this->login_credentials['using_deprecated_option'] ) : ?>
-		<?php
-			echo sprintf(
-				// translators: 1) is the version number of the Salesforce REST API, 2) is the option key for where the deprecated version is stored, and 3) is the prefixed options table name.
-				esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, set it to %4$s so the plugin can delete it, or wait until that release.', 'object-sync-for-salesforce' ),
-				esc_attr( $this->login_credentials['rest_api_version'] ),
-				'<code>' . esc_attr( $this->option_prefix . 'api_version' ) . '</code>',
-				'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>',
-				'<code>' . esc_attr( OBJECT_SYNC_SF_DEFAULT_API_VERSION ) . '</code>'
-			);
-		?>
+		<?php echo wp_kses_post( $this->notices_data['deprecated_api_version']['message'] ); ?>
 	<?php else : ?>
 		<?php
 			echo sprintf(
@@ -45,7 +36,7 @@
 	<table class="widefat striped">
 		<thead>
 			<summary>
-				<h4><?php echo $contacts_apicall_summary; ?></h4>
+				<p><?php echo wp_kses_post( $contacts_apicall_summary ); ?></p>
 			</summary>
 			<tr>
 				<th><?php echo esc_html__( 'Contact ID', 'object-sync-for-salesforce' ); ?></th>

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -8,15 +8,20 @@
 ?>
 
 <h3><?php echo esc_html__( 'Salesforce Status', 'object-sync-for-salesforce' ); ?></h3>
-<p>
-<?php
-	echo sprintf(
-		// translators: placeholder is for the version number of the Salesforce REST API.
-		esc_html__( 'The plugin is using version %1$s of the Salesforce REST API. If the plugin settings are not overriding the default value, the plugin changes to support new API versions regularly.', 'object-sync-for-salesforce' ),
-		esc_html( $this->login_credentials['rest_api_version'] )
-	);
+
+<?php if ( false === $this->login_credentials['using_deprecated_option'] && false === $this->login_credentials['using_developer_filter'] ) : ?>
+	<p>
+	<?php
+		echo sprintf(
+			// translators: placeholder is for the version number of the Salesforce REST API.
+			esc_html__( 'The plugin is using version %1$s of the Salesforce REST API. This is the recommended configuration.', 'object-sync-for-salesforce' ),
+			esc_html( $this->login_credentials['rest_api_version'] )
+		);
 	?>
-</p>
+	</p>
+<?php else : ?>
+	<?php echo esc_html( $this->login_credentials['rest_api_version'] ); ?>
+<?php endif; ?>
 
 <h3><?php echo esc_html__( 'Test Salesforce API Call', 'object-sync-for-salesforce' ); ?></h3>
 <?php if ( '' !== $contacts_apicall_summary ) : ?>

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -12,41 +12,13 @@
 <?php
 	echo sprintf(
 		// translators: placeholder is for the version number of the Salesforce REST API.
-		esc_html__( 'Currently, we are using version %1$s of the Salesforce REST API. Available versions are displayed below.', 'object-sync-for-salesforce' ),
+		esc_html__( 'The plugin is using version %1$s of the Salesforce REST API. If the plugin settings are not overriding the default value, the plugin changes to support new API versions regularly.', 'object-sync-for-salesforce' ),
 		esc_html( $this->login_credentials['rest_api_version'] )
 	);
 	?>
 </p>
-<table class="widefat striped sfwp-salesforce-version-list">
-	<thead>
-		<summary>
-			<h4><?php echo $versions_apicall_summary; ?></h4>
-		</summary>
-		<tr>
-			<th><?php echo esc_html__( 'Version Number', 'object-sync-for-salesforce' ); ?></th>
-			<th><?php echo esc_html__( 'URL', 'object-sync-for-salesforce' ); ?></th>
-			<th><?php echo esc_html__( 'Label', 'object-sync-for-salesforce' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php foreach ( $versions['data'] as $version ) { ?>
-			<?php
-			$class      = '';
-			$is_current = '';
-			if ( $version['version'] === $this->login_credentials['rest_api_version'] ) {
-				$class      = ' class="current"';
-				$is_current = '&nbsp;' . esc_html__( 'This is the currently active version.', 'object-sync-for-salesforce' );
-			}
-			?>
-			<tr<?php echo $class; ?>>
-				<td><strong><?php echo esc_html( $version['version'] ); ?></strong><?php echo $is_current; ?></td>
-				<td><?php echo esc_html( $version['url'] ); ?></td>
-				<td><?php echo esc_html( $version['label'] ); ?></td>
-			</tr>
-		<?php } ?>
-	</tbody>
-</table>
 
+<h3><?php echo esc_html__( 'Test Salesforce API Call', 'object-sync-for-salesforce' ); ?></h3>
 <?php if ( '' !== $contacts_apicall_summary ) : ?>
 	<table class="widefat striped">
 		<thead>

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -22,10 +22,11 @@
 		<?php
 			echo sprintf(
 				// translators: 1) is the version number of the Salesforce REST API, 2) is the option key for where the deprecated version is stored, and 3) is the prefixed options table name.
-				esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, or wait until that release.', 'object-sync-for-salesforce' ),
+				esc_html__( 'Object Sync for Salesforce is using version %1$s of the Salesforce REST API, which is configured from a previous version. This value is no longer configurable in the plugin settings, and in version 3.0.0, previously saved values will be removed. You can delete the %2$s field from the %3$s table on your own, set it to %4$s so the plugin can delete it, or wait until that release.', 'object-sync-for-salesforce' ),
 				esc_attr( $this->login_credentials['rest_api_version'] ),
 				'<code>' . esc_attr( $this->option_prefix . 'api_version' ) . '</code>',
-				'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>'
+				'<code>' . esc_attr( $this->wpdb->prefix . 'options' ) . '</code>',
+				'<code>' . esc_attr( OBJECT_SYNC_SF_DEFAULT_API_VERSION ) . '</code>'
 			);
 		?>
 	<?php else : ?>

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -7,21 +7,26 @@
 
 ?>
 
-<h3><?php echo esc_html__( 'Salesforce Status', 'object-sync-for-salesforce' ); ?></h3>
+<h3><?php echo esc_html__( 'Salesforce API Connection Status', 'object-sync-for-salesforce' ); ?></h3>
 
-<?php if ( false === $this->login_credentials['using_deprecated_option'] && false === $this->login_credentials['using_developer_filter'] ) : ?>
-	<p>
+<p>
 	<?php
-		echo sprintf(
-			// translators: placeholder is for the version number of the Salesforce REST API.
-			esc_html__( 'The plugin is using version %1$s of the Salesforce REST API. This is the recommended configuration.', 'object-sync-for-salesforce' ),
-			esc_html( $this->login_credentials['rest_api_version'] )
-		);
+	echo sprintf(
+		// translators: placeholder is for the version number of the Salesforce REST API.
+		esc_html__( 'Object Sync for Salesforce is making calls to the Salesforce REST API using version %1$s. ', 'object-sync-for-salesforce' ),
+		esc_html( $this->login_credentials['rest_api_version'] )
+	);
 	?>
-	</p>
-<?php else : ?>
-	<?php echo esc_html( $this->login_credentials['rest_api_version'] ); ?>
-<?php endif; ?>
+	<?php if ( false === $this->login_credentials['using_deprecated_option'] && false === $this->login_credentials['using_developer_filter'] ) : ?>
+		<?php
+			echo esc_html__( 'This plugin works to keep up to date with the release cycle of API versions from Salesforce. When a new version is released, the plugin will upgrade to that version as soon as possible. If you upgrade the plugin when new releases come out, you will always be on the highest supported version of the Salesforce REST API. Object Sync for Salesforce will not include plugin functionality that depends on a version it does not support, and will ensure that all releases follow this pattern.', 'object-sync-for-salesforce' );
+		?>
+	<?php elseif ( true === $this->login_credentials['using_deprecated_option'] ) : ?>
+		<?php echo esc_html__( 'This API version is set from a previous version of the plugin, and the plugin functionality of choosing the API version in the interface has been deprecated. In a future release (likely version 3.0.0), the ability to use the REST API version set by the interface will be removed.', 'object-sync-for-salesforce' ); ?>
+	<?php else : ?>
+		<?php echo esc_html__( 'This API version is set with the use of a developer hook.', 'object-sync-for-salesforce' ); ?>
+	<?php endif; ?>
+</p>
 
 <h3><?php echo esc_html__( 'Test Salesforce API Call', 'object-sync-for-salesforce' ); ?></h3>
 <?php if ( '' !== $contacts_apicall_summary ) : ?>
@@ -31,8 +36,8 @@
 				<h4><?php echo $contacts_apicall_summary; ?></h4>
 			</summary>
 			<tr>
-				<th><?php echo esc_html__( 'Contact ID' ); ?></th>
-				<th><?php echo esc_html__( 'Name' ); ?></th>
+				<th><?php echo esc_html__( 'Contact ID', 'object-sync-for-salesforce' ); ?></th>
+				<th><?php echo esc_html__( 'Name', 'object-sync-for-salesforce' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #458 by removing the requirement to set the Salesforce REST API version from the interface in favor of a plugin-wide setting. This setting allows us to track Salesforce API releases within the plugin itself rather than putting that responsibility onto users.

For backward-compatibility, for the time being the plugin will use previously-provided settings (both as config values and as `wp_options` values) and show a notice to users if they are using one of those settings.

For future developer flexibility, this also adds a developer hook in case developers want to set their own version of the API.

## How do I test this Pull Request?

- use the plugin without any previously set version: it should use the value from the object-sync-for-salesforce.php file (currently 55.0).
- use the plugin with a previously set config value that is not 55.0
- use the plugin with a previously set `wp_options` value that is not 55.0
- use the plugin with a developer hook value that is not 55.0.