### PR TITLE
Start to clean up log code. Because of old code that was never updated, our log method was called 1) incorrectly, and 2) in an overly redundant way.

### DIFF
--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -483,12 +483,6 @@ class Object_Sync_Sf_Admin {
 			$status = 'error';
 		}
 
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-
 		$body = sprintf( esc_html__( 'These are the scheduled tasks that were updated: ', 'object-sync-for-salesforce' ) . '<ul>' );
 		foreach ( $schedules_updated as $schedule_updated ) {
 			$body .= sprintf(
@@ -516,7 +510,7 @@ class Object_Sync_Sf_Admin {
 			esc_html__( 'Scheduling', 'object-sync-for-salesforce' )
 		);
 
-		$logging->setup(
+		$this->logging->setup(
 			sprintf(
 				// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
 				esc_html__( '%1$s ActionScheduler: the ActionScheduler library has completed its migration. See the log entry content for status on each recurring task.', 'object-sync-for-salesforce' ),
@@ -2089,13 +2083,7 @@ class Object_Sync_Sf_Admin {
 
 		if ( ! empty( $error_fieldmaps ) && ! empty( $error_object_maps ) ) {
 			$status = 'error';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
-			$body = sprintf( esc_html__( 'These are the import items that were not able to save: ', 'object-sync-for-salesforce' ) . '<ul>' );
+			$body   = sprintf( esc_html__( 'These are the import items that were not able to save: ', 'object-sync-for-salesforce' ) . '<ul>' );
 			foreach ( $error_fieldmaps as $fieldmap ) {
 				$body .= sprintf(
 					// translators: placeholders are: 1) the fieldmap row ID, 2) the Salesforce object type, 3) the WordPress object type.
@@ -2116,7 +2104,7 @@ class Object_Sync_Sf_Admin {
 			}
 			$body .= sprintf( '</ul>' );
 
-			$logging->setup(
+			$this->logging->setup(
 				sprintf(
 					// translators: %1$s is the log status.
 					esc_html__( '%1$s on import: some of the rows were unable to save. Read this post for details.', 'object-sync-for-salesforce' ),

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -324,8 +324,8 @@ class Object_Sync_Sf_Mapping {
 		$this->status_success = 1;
 		$this->status_error   = 0;
 
-		$this->debug = get_option( $this->option_prefix . 'debug_mode', false );
-		$this->debug = filter_var( $this->debug, FILTER_VALIDATE_BOOLEAN );
+		// use the option value for whether we're in debug mode.
+		$this->debug = filter_var( get_option( $this->option_prefix . 'debug_mode', false ), FILTER_VALIDATE_BOOLEAN );
 
 	}
 
@@ -663,12 +663,7 @@ class Object_Sync_Sf_Mapping {
 			$insert = $this->wpdb->insert( $this->object_map_table, $data );
 		} else {
 			$status = 'error';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-			$logging->setup(
+			$this->logging->setup(
 				sprintf(
 					// translators: %1$s is the log status, %2$s is the name of a WordPress object. %3$s is the id of that object.
 					esc_html__( '%1$s Mapping: error caused by trying to map the WordPress %2$s with ID of %3$s to Salesforce ID starting with "tmp_sf_", which is invalid.', 'object-sync-for-salesforce' ),
@@ -690,12 +685,7 @@ class Object_Sync_Sf_Mapping {
 			$mapping = $this->load_object_maps_by_salesforce_id( $data['salesforce_id'] )[0];
 			$id      = $mapping['id'];
 			$status  = 'error';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-			$logging->setup(
+			$this->logging->setup(
 				sprintf(
 					// translators: %1$s is the status word "Error". %2$s is the Id of a Salesforce object. %3$s is the ID of a mapping object.
 					esc_html__( '%1$s: Mapping: there is already a WordPress object mapped to the Salesforce object %2$s and the mapping object ID is %3$s', 'object-sync-for-salesforce' ),

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -194,8 +194,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 		// deprecated actions.
 		$this->deprecated_actions();
 
-		$this->debug = get_option( $this->option_prefix . 'debug_mode', false );
-		$this->debug = filter_var( $this->debug, FILTER_VALIDATE_BOOLEAN );
+		// use the option value for whether we're in debug mode.
+		$this->debug = filter_var( get_option( $this->option_prefix . 'debug_mode', false ), FILTER_VALIDATE_BOOLEAN );
 
 	}
 
@@ -419,13 +419,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 								ucfirst( esc_attr( $status ) ),
 								esc_attr( $result['Id'] )
 							);
-
-							if ( isset( $this->logging ) ) {
-								$logging = $this->logging;
-							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-							}
-
 							$debug = array(
 								'title'   => $title,
 								'message' => esc_html__( 'This ID has already been attempted so it was not pulled again.', 'object-sync-for-salesforce' ),
@@ -433,8 +426,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 								'parent'  => '',
 								'status'  => $status,
 							);
-
-							$logging->setup( $debug );
+							$this->logging->setup( $debug );
 						}
 
 						continue;
@@ -470,13 +462,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 									ucfirst( esc_attr( $status ) ),
 									esc_attr( $result['Id'] )
 								);
-
-								if ( isset( $this->logging ) ) {
-									$logging = $this->logging;
-								} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-									$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-								}
-
 								$debug = array(
 									'title'   => $title,
 									'message' => esc_html__( 'This ID is not pullable so it was skipped.', 'object-sync-for-salesforce' ),
@@ -484,8 +469,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 									'parent'  => '',
 									'status'  => $status,
 								);
-
-								$logging->setup( $debug );
+								$this->logging->setup( $debug );
 							}
 							continue;
 						}
@@ -499,13 +483,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 								ucfirst( esc_attr( $status ) ),
 								esc_attr( $result['Id'] )
 							);
-
-							if ( isset( $this->logging ) ) {
-								$logging = $this->logging;
-							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-							}
-
 							$message = sprintf(
 								// translators: 1) is the name of the hook that was called, 2) is the Salesforce object type, 3) is the ID for the object map, 4) is the event trigger that is running, and 5) is the name of the schedule that is running.
 								esc_html__( 'This record is being sent to the queue. The hook name is %1$s. The arguments for the hook are: object type %2$s, object map ID %3$s, sync trigger %4$s. The schedule name is %5$s.', 'object-sync-for-salesforce' ),
@@ -515,7 +492,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 								$sf_sync_trigger,
 								$this->schedule_name
 							);
-
 							$debug = array(
 								'title'   => $title,
 								'message' => $message,
@@ -523,8 +499,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 								'parent'  => '',
 								'status'  => $status,
 							);
-
-							$logging->setup( $debug );
+							$this->logging->setup( $debug );
 						}
 
 						// add a queue action to save data from salesforce.
@@ -548,13 +523,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 								ucfirst( esc_attr( $status ) ),
 								esc_attr( $result['Id'] )
 							);
-
-							if ( isset( $this->logging ) ) {
-								$logging = $this->logging;
-							} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-								$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-							}
-
 							$debug = array(
 								'title'   => $title,
 								'message' => esc_html__( 'This ID has been successfully pulled and added to the queue for processing. It cannot be pulled again without being modified again.', 'object-sync-for-salesforce' ),
@@ -562,7 +530,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 								'parent'  => '',
 								'status'  => $status,
 							);
-							$logging->setup( $debug );
+							$this->logging->setup( $debug );
 						} // end of debug
 					} // end if
 				} // end foreach
@@ -622,13 +590,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 					'<p>' . esc_html__( 'Salesforce API Response: %1$s', 'object-sync-for-salesforce' ) . '</p>',
 					$response['message']
 				);
-
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-				}
-
 				$result = array(
 					'title'   => $log_title,
 					'message' => $log_body,
@@ -636,8 +597,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					'parent'  => '',
 					'status'  => $status,
 				);
-
-				$logging->setup( $result );
+				$this->logging->setup( $result );
 			} elseif ( isset( $response['errorCode'] ) ) {
 				// create log entry for failed pull.
 				$status = 'error';
@@ -648,13 +608,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 					esc_attr( $response['errorCode'] ),
 					esc_attr( $salesforce_mapping['salesforce_object'] )
 				);
-
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-				}
-
 				$result = array(
 					'title'   => $title,
 					'message' => $response['message'],
@@ -662,9 +615,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					'parent'  => '',
 					'status'  => $status,
 				);
-
-				$logging->setup( $result );
-
+				$this->logging->setup( $result );
 				return $result;
 
 			} // End if() statement.
@@ -1064,14 +1015,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				$mapping_object                  = $this->mappings->update_object_map( $mapping_object, $mapping_object['id'] );
 
 				$status = 'success';
-
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-				}
-
-				$title = sprintf(
+				$title  = sprintf(
 					// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object type, 4) the previous Salesforce Id value, 5) the new Salesforce Id value, 6) the name of the WordPress object, 7) the WordPress id value.
 					esc_html__( '%1$s: %2$s Salesforce %3$s objects with Ids %4$s and %5$s were merged (%5$s is the remaining ID. It is mapped to WordPress %6$s with %7$s.)', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
@@ -1082,7 +1026,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 					esc_attr( $wordpress_type ),
 					esc_attr( $wordpress_id )
 				);
-
 				$result = array(
 					'title'   => $title,
 					'message' => '',
@@ -1090,8 +1033,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					'parent'  => $wordpress_id,
 					'status'  => $status,
 				);
-
-				$logging->setup( $result );
+				$this->logging->setup( $result );
 
 				// after it has been merged, pull it.
 				$result = $this->manual_pull( $object_type, $new_sf_id );
@@ -1304,13 +1246,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 						esc_html__( '%1$s: we are missing a deletedDate attribute here, but are expected to delete an item.', 'object-sync-for-salesforce' ),
 						ucfirst( esc_attr( $status ) )
 					);
-
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
 					$debug = array(
 						'title'   => $title,
 						'message' => '',
@@ -1318,8 +1253,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						'parent'  => '',
 						'status'  => $status,
 					);
-
-					$logging->setup( $debug );
+					$this->logging->setup( $debug );
 				}
 
 				$object = array(
@@ -1368,13 +1302,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			} else {
 				// if we don't have a Salesforce object id, we've got no business doing stuff in WordPress.
 				$status = 'error';
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-				}
-
-				$title = sprintf(
+				$title  = sprintf(
 					// translators: placeholders are: 1) the log status.
 					esc_html__( '%1$s: Salesforce Pull: unable to process queue item because it has no Salesforce Id.', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) )
@@ -1386,9 +1314,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					'parent'  => 0, // parent id goes here but we don't have one, so make it 0.
 					'status'  => $status,
 				);
-
-				$logging->setup( $result );
-
+				$this->logging->setup( $result );
 				$results[] = $result;
 				continue;
 			}
@@ -1447,13 +1373,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 						ucfirst( esc_attr( $status ) ),
 						$mapping_object_id_transient
 					);
-
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
 					$debug = array(
 						'title'   => $title,
 						'message' => '',
@@ -1461,8 +1380,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						'parent'  => '',
 						'status'  => $status,
 					);
-
-					$logging->setup( $debug );
+					$this->logging->setup( $debug );
 				}
 
 				continue;
@@ -1507,28 +1425,18 @@ class Object_Sync_Sf_Salesforce_Pull {
 					// I think it should be a debug message, unless we learn from users that it should be raised to an error.
 					if ( true === $this->debug ) {
 						$status = 'debug';
-						if ( isset( $this->logging ) ) {
-							$logging = $this->logging;
-						} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-							$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-						}
-
-						$title = sprintf(
+						$title  = sprintf(
 							// translators: %1$s is the log status.
 							esc_html__( '%1$s Mapping: according to the current plugin settings, there are no parameters in the current dataset that can be pulled from Salesforce.', 'object-sync-for-salesforce' ),
 							ucfirst( esc_attr( $status ) )
 						);
-
-						$body = '';
-
-						$body .= sprintf(
+						$body = sprintf(
 							// translators: placeholders are: 1) the fieldmap row ID, 2) the name of the WordPress object, 3) the name of the Salesforce object.
 							'<p>' . esc_html__( 'There is a fieldmap with ID of %1$s and it maps the WordPress %2$s object to the Salesforce %3$s object.', 'object-sync-for-salesforce' ) . '</p>',
 							absint( $salesforce_mapping['id'] ),
 							esc_attr( $salesforce_mapping['wordpress_object'] ),
 							esc_attr( $salesforce_mapping['salesforce_object'] )
 						);
-
 						// whether it's a new mapping object or not.
 						if ( false === $is_new ) {
 							// this one is not new.
@@ -1558,7 +1466,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							print_r( $object, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 						);
 
-						$logging->setup(
+						$this->logging->setup(
 							$title,
 							$body,
 							$sf_sync_trigger,
@@ -1758,7 +1666,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 							esc_html__( '%1$s: There is at least one object map with a WordPress ID of 0.', 'object-sync-for-salesforce' ),
 							ucfirst( esc_attr( $status ) )
 						);
-
 						if ( 1 === count( $mapping_object_debug ) ) {
 							$body = sprintf(
 								// translators: placeholders are: 1) the mapping object row ID, 2) the name of the WordPress object, 3) the ID of the Salesforce object it was trying to map.
@@ -1780,14 +1687,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							}
 							$body .= sprintf( '</ul>' );
 						}
-
-						if ( isset( $this->logging ) ) {
-							$logging = $this->logging;
-						} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-							$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-						}
 						$parent = 0;
-
 						$result = array(
 							'title'   => $title,
 							'message' => $body,
@@ -1795,9 +1695,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							'parent'  => $parent,
 							'status'  => $status,
 						);
-
-						$logging->setup( $result );
-
+						$this->logging->setup( $result );
 						$results[] = $result;
 					} // End if() statement.
 				} // End if() statement.
@@ -1818,7 +1716,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 						absint( $wordpress_id ),
 						esc_attr( $object['Id'] )
 					);
-
 					$body = sprintf(
 						// translators: placeholders are 1) WordPress object type, 2) field name for the WordPress id, 3) the WordPress id value, 4) the Salesforce object type, 5) the Salesforce object Id that was modified, 6) the mapping object row id.
 						esc_html__( 'The WordPress %1$s with %2$s of %3$s is already mapped to the Salesforce %4$s with Id of %5$s in the mapping object with id of %6$s. The Salesforce %4$s with Id of %5$s was created or modified in Salesforce, and would otherwise have been mapped to this WordPress record. No WordPress data has been changed to prevent changing data unintentionally.', 'object-sync-for-salesforce' ),
@@ -1829,20 +1726,12 @@ class Object_Sync_Sf_Salesforce_Pull {
 						esc_attr( $object['Id'] ),
 						absint( $mapping_object['id'] )
 					);
-
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
 					// if we know the WordPress object id we can put it in there.
 					if ( null !== $wordpress_id ) {
 						$parent = $wordpress_id;
 					} else {
 						$parent = 0;
 					}
-
 					$result = array(
 						'title'   => $title,
 						'message' => $body,
@@ -1850,9 +1739,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						'parent'  => $parent,
 						'status'  => $status,
 					);
-
-					$logging->setup( $result );
-
+					$this->logging->setup( $result );
 					$results[] = $result;
 
 				} // End if() statement.
@@ -1902,31 +1789,21 @@ class Object_Sync_Sf_Salesforce_Pull {
 				esc_attr( $op ),
 				esc_attr( $salesforce_mapping['wordpress_object'] )
 			);
-
 			if ( null !== $salesforce_id ) {
 				$title .= ' ' . $salesforce_id;
 			}
-
 			$title .= sprintf(
 				// translators: placeholders are: 1) the name of the Salesforce object, and 2) Id of the Salesforce object.
 				esc_html__( ' (Salesforce %1$s with Id of %2$s)', 'object-sync-for-salesforce' ),
 				$salesforce_mapping['salesforce_object'],
 				$object['Id']
 			);
-
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
 			// if we know the WordPress object id we can put it in there.
 			if ( null !== $wordpress_id ) {
 				$parent = $wordpress_id;
 			} else {
 				$parent = 0;
 			}
-
 			$result = array(
 				'title'   => $title,
 				'message' => $e->getMessage(),
@@ -1934,11 +1811,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 				'parent'  => $parent,
 				'status'  => $status,
 			);
-
-			$logging->setup( $result );
-
+			$this->logging->setup( $result );
 			$results[] = $result;
-
 			if ( false === $hold_exceptions ) {
 				throw $e;
 			}
@@ -1968,14 +1842,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 		if ( empty( $result['errors'] ) ) {
 			$status = 'success';
-
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
-			$title = sprintf(
+			$title  = sprintf(
 				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value.
 				esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (Salesforce %6$s Id of %7$s)', 'object-sync-for-salesforce' ),
 				ucfirst( esc_attr( $status ) ),
@@ -1986,7 +1853,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 				esc_attr( $salesforce_mapping['salesforce_object'] ),
 				esc_attr( $object['Id'] )
 			);
-
 			$result = array(
 				'title'   => $title,
 				'message' => '',
@@ -1994,9 +1860,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				'parent'  => $wordpress_id,
 				'status'  => $status,
 			);
-
-			$logging->setup( $result );
-
+			$this->logging->setup( $result );
 			$results[] = $result;
 
 			// update that mapping object.
@@ -2011,17 +1875,10 @@ class Object_Sync_Sf_Salesforce_Pull {
 			// this is part of the drupal module but i am failing to understand when it would ever fire, since the catch should catch the errors
 			// if we see this in the log entries, we can understand what it does, but probably not until then.
 			$status = 'error';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
 			if ( is_object( $wordpress_id ) ) {
 				// print this array because if this happens, something weird has happened and we want to log whatever we have.
 				$wordpress_id = print_r( $wordpress_id, true ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			}
-
 			$title = sprintf(
 				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the Salesforce object type, 4) the Salesforce object Id value.
 				esc_html__( '%1$s syncing: %2$s to WordPress (Salesforce %3$s Id %4$s)', 'object-sync-for-salesforce' ),
@@ -2030,7 +1887,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 				esc_attr( $salesforce_mapping['salesforce_object'] ),
 				esc_attr( $object['Id'] )
 			);
-
 			$body = sprintf(
 				// translators: placeholders are: 1) the name of the WordPress object type, 2) the WordPress id field name, 3) the WordPress id field value, 4) the array of errors.
 				'<p>' . esc_html__( 'Object: %1$s with %2$s of %3$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: ', 'object-sync-for-salesforce' ) . '%4$s</p>',
@@ -2039,7 +1895,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 				esc_attr( $wordpress_id ),
 				print_r( $result['errors'], true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			);
-
 			$result = array(
 				'title'   => $title,
 				'message' => $body,
@@ -2047,9 +1902,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				'parent'  => $wordpress_id,
 				'status'  => $status,
 			);
-
-			$logging->setup( $result );
-
+			$this->logging->setup( $result );
 			$results[] = $result;
 
 			// hook for pull fail.
@@ -2101,13 +1954,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			$mapping_object['last_sync_message'] = esc_html__( 'Mapping object updated via function: ', 'object-sync-for-salesforce' ) . __FUNCTION__;
 
 			$status = 'success';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
-			$title = sprintf(
+			$title  = sprintf(
 				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value.
 				esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (Salesforce %6$s Id of %7$s)', 'object-sync-for-salesforce' ),
 				ucfirst( esc_attr( $status ) ),
@@ -2118,7 +1965,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 				esc_attr( $salesforce_mapping['salesforce_object'] ),
 				esc_attr( $object['Id'] )
 			);
-
 			$result = array(
 				'title'   => $title,
 				'message' => '',
@@ -2126,8 +1972,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				'parent'  => $mapping_object['wordpress_id'],
 				'status'  => $status,
 			);
-
-			$logging->setup( $result );
+			$this->logging->setup( $result );
 
 			$results[] = $result;
 
@@ -2137,13 +1982,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		} catch ( Object_Sync_Sf_Exception $e ) {
 			// create log entry for failed update.
 			$status = 'error';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
-			$title .= sprintf(
+			$title  = sprintf(
 				// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value.
 				esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (Salesforce %6$s with Id of %7$s)', 'object-sync-for-salesforce' ),
 				ucfirst( esc_attr( $status ) ),
@@ -2154,7 +1993,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 				esc_attr( $salesforce_mapping['salesforce_object'] ),
 				esc_attr( $object['Id'] )
 			);
-
 			$result = array(
 				'title'   => $title,
 				'message' => $e->getMessage(),
@@ -2162,9 +2000,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 				'parent'  => $mapping_object['wordpress_id'],
 				'status'  => $status,
 			);
-
-			$logging->setup( $result );
-
+			$this->logging->setup( $result );
 			$results[] = $result;
 
 			$mapping_object['last_sync_status']  = $this->mappings->status_error;
@@ -2236,12 +2072,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 					} catch ( Object_Sync_Sf_Exception $e ) {
 						$status = 'error';
 						// create log entry for failed delete.
-						if ( isset( $this->logging ) ) {
-							$logging = $this->logging;
-						} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-							$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-						}
-
 						$title = sprintf(
 							// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value.
 							esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (%6$s %7$s)', 'object-sync-for-salesforce' ),
@@ -2253,7 +2083,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 							esc_attr( $salesforce_mapping['salesforce_object'] ),
 							esc_attr( $mapping_object['salesforce_id'] )
 						);
-
 						$result = array(
 							'title'   => $title,
 							'message' => $e->getMessage(),
@@ -2261,9 +2090,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							'parent'  => $mapping_object['wordpress_id'],
 							'status'  => $status,
 						);
-
-						$logging->setup( $result );
-
+						$this->logging->setup( $result );
 						$results[] = $result;
 
 						if ( false === $hold_exceptions ) {
@@ -2284,13 +2111,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					if ( ! isset( $e ) ) {
 						// create log entry for successful delete if the result had no errors.
 						$status = 'success';
-						if ( isset( $this->logging ) ) {
-							$logging = $this->logging;
-						} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-							$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-						}
-
-						$title = sprintf(
+						$title  = sprintf(
 							// translators: placeholders are: 1) the log status, 2) what operation is happening, 3) the name of the WordPress object type, 4) the WordPress id field name, 5) the WordPress object id value, 6) the name of the Salesforce object, 7) the Salesforce Id value.
 							esc_html__( '%1$s: %2$s WordPress %3$s with %4$s of %5$s (%6$s %7$s)', 'object-sync-for-salesforce' ),
 							ucfirst( esc_attr( $status ) ),
@@ -2301,7 +2122,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 							esc_attr( $salesforce_mapping['salesforce_object'] ),
 							esc_attr( $mapping_object['salesforce_id'] )
 						);
-
 						$result = array(
 							'title'   => $title,
 							'message' => '',
@@ -2309,9 +2129,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 							'parent'  => $mapping_object['wordpress_id'],
 							'status'  => $status,
 						);
-
-						$logging->setup( $result );
-
+						$this->logging->setup( $result );
 						$results[] = $result;
 
 						// hook for pull success.
@@ -2334,13 +2152,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 					$more_ids .= '<p>' . esc_html__( 'The map row between this Salesforce object and the WordPress object, as stored in the WordPress database, will be deleted, and this Salesforce object has been deleted, but WordPress object data will remain untouched.', 'object-sync-for-salesforce' ) . '</p>';
 
 					$status = 'notice';
-					if ( isset( $this->logging ) ) {
-						$logging = $this->logging;
-					} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-						$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-					}
-
-					$title = sprintf(
+					$title  = sprintf(
 						// translators: placeholders are: 1) the operation that is happening, 2) the name of the WordPress object type, 3) the WordPress id field name, 4) the WordPress object id value, 5) the name of the Salesforce object type, 6) the Salesforce Id.
 						esc_html__( '%1$s: %2$s on WordPress %3$s with %4$s of %5$s was stopped because there are other WordPress records mapped to Salesforce %6$s of %7$s', 'object-sync-for-salesforce' ),
 						ucfirst( esc_attr( $status ) ),
@@ -2351,7 +2163,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 						esc_attr( $salesforce_mapping['salesforce_object'] ),
 						esc_attr( $mapping_object['salesforce_id'] )
 					);
-
 					$notice = array(
 						'title'   => $title,
 						'message' => $more_ids,
@@ -2359,8 +2170,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						'parent'  => 0,
 						'status'  => $status,
 					);
-
-					$logging->setup( $notice );
+					$this->logging->setup( $notice );
 				} // End if() on count
 				// delete the map row from WordPress after the WordPress row has been deleted
 				// we delete the map row even if the WordPress delete failed, because the Salesforce object is gone.

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -193,8 +193,8 @@ class Object_Sync_Sf_Salesforce {
 		$this->success_or_refresh_codes   = $this->success_codes;
 		$this->success_or_refresh_codes[] = $this->refresh_code;
 
-		$this->debug = get_option( $this->option_prefix . 'debug_mode', false );
-		$this->debug = filter_var( $this->debug, FILTER_VALIDATE_BOOLEAN );
+		// use the option value for whether we're in debug mode.
+		$this->debug = filter_var( get_option( $this->option_prefix . 'debug_mode', false ), FILTER_VALIDATE_BOOLEAN );
 
 	}
 
@@ -398,12 +398,6 @@ class Object_Sync_Sf_Salesforce {
 		if ( true === $this->debug ) {
 			// create log entry for the api call if debug is true.
 			$status = 'debug';
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				global $wpdb;
-				$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
-			}
 
 			// try to get the SOQL query if there was one.
 			parse_str( $url, $salesforce_url_parts );
@@ -434,21 +428,16 @@ class Object_Sync_Sf_Salesforce {
 				ucfirst( esc_attr( $status ) ),
 				( false === $is_soql_query ) ? esc_html__( 'There is not an SOQL query included in this request.', 'object-sync-for-salesforce' ) : esc_html__( 'There is an SOQL query included in this request.', 'object-sync-for-salesforce' )
 			);
-
-			$body = '';
-
-			$body .= sprintf(
+			$body = sprintf(
 				// translators: placeholder is: 1) the API call's HTTP method.
 				'<p><strong>' . esc_html__( 'HTTP method:', 'object-sync-for-salesforce' ) . '</strong> %1$s</p>',
 				esc_attr( $method )
 			);
-
 			$body .= sprintf(
 				// translators: placeholder is: 1) the API call's URL.
 				'<p><strong>' . esc_html__( 'URL of API call to Salesforce:', 'object-sync-for-salesforce' ) . '</strong> %1$s</p>',
 				esc_url( $url )
 			);
-
 			if ( true === $is_soql_query ) {
 				$query = $salesforce_url_parts[ $query_key ];
 				$soql  = urldecode( $query );
@@ -458,14 +447,12 @@ class Object_Sync_Sf_Salesforce {
 					'<code>' . esc_html( $soql ) . '</code>'
 				);
 			}
-
 			$body .= sprintf(
 				// translators: placeholder is: 1) the API call's result.
 				'<h3>' . esc_html__( 'API result from Salesforce', 'object-sync-for-salesforce' ) . '</h3> <div>%1$s</div>',
 				print_r( $result, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			);
-
-			$logging->setup(
+			$this->logging->setup(
 				$title,
 				$body,
 				0,
@@ -557,21 +544,13 @@ class Object_Sync_Sf_Salesforce {
 			if ( '' !== $curl_error ) {
 				// create log entry for failed curl.
 				$status = 'error';
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					global $wpdb;
-					$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
-				}
-
-				$title = sprintf(
+				$title  = sprintf(
 					// translators: placeholders are: 1) the log status, 2) the HTTP status code returned by the Salesforce API request.
 					esc_html__( '%1$s: %2$s: on Salesforce HTTP request', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
 					absint( $code )
 				);
-
-				$logging->setup(
+				$this->logging->setup(
 					$title,
 					$curl_error,
 					0,
@@ -581,20 +560,12 @@ class Object_Sync_Sf_Salesforce {
 			} elseif ( isset( $data[0]['errorCode'] ) && '' !== $data[0]['errorCode'] ) { // salesforce uses this structure to return errors
 				// create log entry for failed curl.
 				$status = 'error';
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					global $wpdb;
-					$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
-				}
-
-				$title = sprintf(
+				$title  = sprintf(
 					// translators: placeholders are: 1) the log status, 2) the HTTP status code returned by the Salesforce API request.
 					esc_html__( '%1$s: %2$s: on Salesforce HTTP request', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
 					absint( $code )
 				);
-
 				$body = sprintf(
 					// translators: placeholders are: 1) the URL requested, 2) the message returned by the error, 3) the server code returned.
 					'<p>' . esc_html__( 'URL: %1$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Message: %2$s', 'object-sync-for-salesforce' ) . '</p><p>' . esc_html__( 'Code: %3$s', 'object-sync-for-salesforce' ),
@@ -602,8 +573,7 @@ class Object_Sync_Sf_Salesforce {
 					esc_html( $data[0]['message'] ),
 					absint( $code )
 				);
-
-				$logging->setup(
+				$this->logging->setup(
 					$title,
 					$body,
 					0,
@@ -613,21 +583,13 @@ class Object_Sync_Sf_Salesforce {
 			} else {
 				// create log entry for failed curl.
 				$status = 'error';
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					global $wpdb;
-					$logging = new Object_Sync_Sf_Logging( $wpdb, $this->version );
-				}
-
-				$title = sprintf(
+				$title  = sprintf(
 					// translators: placeholders are: 1) the log status, 2) the HTTP status code returned by the Salesforce API request.
 					esc_html__( '%1$s: %2$s: on Salesforce HTTP request', 'object-sync-for-salesforce' ),
 					ucfirst( esc_attr( $status ) ),
 					absint( $code )
 				);
-
-				$logging->setup(
+				$this->logging->setup(
 					$title,
 					print_r( $data, true ), // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					0,

--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -118,8 +118,8 @@ class Object_Sync_Sf_WordPress {
 
 		$this->sfwp_transients = new Object_Sync_Sf_WordPress_Transient( 'sfwp_transients' );
 
-		$this->debug = get_option( $this->option_prefix . 'debug_mode', false );
-		$this->debug = filter_var( $this->debug, FILTER_VALIDATE_BOOLEAN );
+		// use the option value for whether we're in debug mode.
+		$this->debug = filter_var( get_option( $this->option_prefix . 'debug_mode', false ), FILTER_VALIDATE_BOOLEAN );
 
 	}
 
@@ -877,21 +877,12 @@ class Object_Sync_Sf_WordPress {
 					esc_attr( $mapping_object['salesforce_id'] )
 				);
 			}
-
-			if ( isset( $this->logging ) ) {
-				$logging = $this->logging;
-			} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-				$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-			}
-
-			$body  = '';
-			$body .= '<h2>' . esc_html__( 'Errors from WordPress result:', 'object-sync-for-salesforce' ) . '</h2>';
+			$body  = '<h2>' . esc_html__( 'Errors from WordPress result:', 'object-sync-for-salesforce' ) . '</h2>';
 			$body .= esc_html( print_r( $result['errors'], true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			if ( is_array( $params ) && ! empty( $params ) ) {
 				$body .= '<h2>' . esc_html__( 'Parameters sent to WordPress:', 'object-sync-for-salesforce' ) . '</h2>';
 				$body .= esc_html( print_r( $params, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 			}
-
 			$error_log = array(
 				'title'   => $title,
 				'message' => $body,
@@ -899,7 +890,7 @@ class Object_Sync_Sf_WordPress {
 				'parent'  => '',
 				'status'  => $status,
 			);
-			$logging->setup( $error_log );
+			$this->logging->setup( $error_log );
 		}
 
 		return $result;
@@ -1187,20 +1178,13 @@ class Object_Sync_Sf_WordPress {
 		}
 
 		// Create log entry for lack of a user id.
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-
 		$status = 'error';
 		$title  = sprintf(
 			// translators: placeholders are: 1) the log status.
 			esc_html__( '%1$s: Users: Tried to run user_upsert, and ended up without a user id', 'object-sync-for-salesforce' ),
 			ucfirst( esc_attr( $status ) )
 		);
-
-		$logging->setup(
+		$this->logging->setup(
 			// todo: can we get any more specific about this?
 			$title,
 			'',
@@ -1524,20 +1508,13 @@ class Object_Sync_Sf_WordPress {
 			return $result;
 		}
 		// Create log entry for lack of a post id.
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-
 		$status = 'error';
 		$title  = sprintf(
 			// translators: placeholders are: 1) the log status.
 			esc_html__( '%1$s: Posts: Tried to run post_upsert, and ended up without a post id', 'object-sync-for-salesforce' ),
 			ucfirst( esc_attr( $status ) )
 		);
-
-		$logging->setup(
+		$this->logging->setup(
 			// todo: can we be more explicit here about what post upsert failed?
 			$title,
 			'',
@@ -1838,20 +1815,13 @@ class Object_Sync_Sf_WordPress {
 		}
 
 		// Create log entry for lack of an attachment id.
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-
 		$status = 'error';
 		$title  = sprintf(
 			// translators: placeholders are: 1) the log status.
 			esc_html__( '%1$s: Attachments: Tried to run attachment_upsert, and ended up without an attachment id', 'object-sync-for-salesforce' ),
 			ucfirst( esc_attr( $status ) )
 		);
-
-		$logging->setup(
+		$this->logging->setup(
 			$title,
 			'',
 			0,
@@ -2164,20 +2134,13 @@ class Object_Sync_Sf_WordPress {
 			return $result;
 		}
 		// Create log entry for lack of a term id.
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-
 		$status = 'error';
 		$title  = sprintf(
 			// translators: placeholders are: 1) the log status.
 			esc_html__( '%1$s: Terms: Tried to run term_upsert, and ended up without a term id', 'object-sync-for-salesforce' ),
 			ucfirst( esc_attr( $status ) )
 		);
-
-		$logging->setup(
+		$this->logging->setup(
 			$title,
 			'',
 			0,
@@ -2409,12 +2372,7 @@ class Object_Sync_Sf_WordPress {
 			} elseif ( count( $comments ) > 1 ) {
 				$status = 'error';
 				// Create log entry for multiple matches.
-				if ( isset( $this->logging ) ) {
-					$logging = $this->logging;
-				} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-					$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-				}
-				$logging->setup(
+				$this->logging->setup(
 					sprintf(
 						// translators: %1$s is the log status. %2$s is a number. %3$s is a key. %4$s is the value of that key. %5$s is a var_export'd array of comments.
 						esc_html__( '%1$s: Comments: there are %2$s comment matches for the Salesforce key %3$s with the value of %4$s. Here they are: %5$s', 'object-sync-for-salesforce' ),
@@ -2494,20 +2452,13 @@ class Object_Sync_Sf_WordPress {
 		}
 
 		// Create log entry for lack of a comment id.
-		if ( isset( $this->logging ) ) {
-			$logging = $this->logging;
-		} elseif ( class_exists( 'Object_Sync_Sf_Logging' ) ) {
-			$logging = new Object_Sync_Sf_Logging( $this->wpdb, $this->version );
-		}
-
 		$status = 'error';
 		$title  = sprintf(
 			// translators: placeholders are: 1) the log status.
 			esc_html__( '%1$s: Comments: Tried to run comment_upsert, and ended up without a comment id', 'object-sync-for-salesforce' ),
 			ucfirst( esc_attr( $status ) )
 		);
-
-		$logging->setup(
+		$this->logging->setup(
 			$title,
 			'',
 			0,


### PR DESCRIPTION
## What does this Pull Request do?

This is a start at addressing #459. All it really does is make all the log class calls correct and less redundant. It should not result in any behavior changes.

## How do I test this Pull Request?

- make sure no plugin behaviors are different.