### PR TITLE
Fix the `pull_merge_last` option value that is used on merge operations

### DIFF
--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -989,7 +989,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			// Iterate over each field mapping to determine our query parameters.
 			foreach ( $mappings as $salesforce_mapping ) {
-				$last_merge_sync = $this->pull_options->get( 'merge_last', $salesforce_mapping['salesforce_object'], '', time() );
+				$last_merge_sync = $this->pull_options->get( 'merge_last', $salesforce_mapping['salesforce_object'], $salesforce_mapping['id'], time() );
 				$now             = time();
 				$this->pull_options->set( 'merge_last', $salesforce_mapping['salesforce_object'], $salesforce_mapping['id'], $now );
 


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #466. The `pull_merge_last` option value is supposed to be fieldmap-specific, ex `object_sync_for_salesforce_pull_merge_last_Contact_2` instead of `object_sync_for_salesforce_pull_merge_last_Contact`. This fixes the problem with the SOQL queries that are used to detect merges.

## How do I test this Pull Request?
- enable merging on a fieldmap
- merge some records that apply to that fieldmap
- see that they are merged

