### PR TITLE
Add an error handler on the Authorize screen in case no data is returned by the demo API call.

### DIFF
--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -2378,38 +2378,43 @@ class Object_Sync_Sf_Admin {
 
 		$contacts = $sfapi->query( 'SELECT Name, Id from Contact LIMIT 100' );
 
-		// format this array into html so users can see the contacts.
-		if ( true === $contacts['cached'] ) {
-			$contacts_is_cached = esc_html__( 'They are cached, and', 'object-sync-for-salesforce' );
+		if ( 200 !== $contacts['code'] ) {
+			$contacts_apicall_summary = esc_html__( 'The plugin was unable to load a sample of Contacts from Salesforce. This may mean that there are connection issues, or that the authorization has expired.', 'object-sync-for-salesforce' );
 		} else {
-			$contacts_is_cached = esc_html__( 'They are not cached, but', 'object-sync-for-salesforce' );
-		}
 
-		if ( true === $contacts['from_cache'] ) {
-			$contacts_from_cache = esc_html__( 'they were loaded from the cache', 'object-sync-for-salesforce' );
-		} else {
-			$contacts_from_cache = esc_html__( 'they were not loaded from the cache', 'object-sync-for-salesforce' );
-		}
+			// format this array into html so users can see the contacts.
+			if ( true === $contacts['cached'] ) {
+				$contacts_is_cached = esc_html__( 'They are cached, and', 'object-sync-for-salesforce' );
+			} else {
+				$contacts_is_cached = esc_html__( 'They are not cached, but', 'object-sync-for-salesforce' );
+			}
 
-		if ( true === $contacts['is_redo'] ) {
-			$contacts_refreshed_token = esc_html__( 'This request did require refreshing the Salesforce token', 'object-sync-for-salesforce' );
-		} else {
-			$contacts_refreshed_token = esc_html__( 'This request did not require refreshing the Salesforce token', 'object-sync-for-salesforce' );
-		}
+			if ( true === $contacts['from_cache'] ) {
+				$contacts_from_cache = esc_html__( 'they were loaded from the cache', 'object-sync-for-salesforce' );
+			} else {
+				$contacts_from_cache = esc_html__( 'they were not loaded from the cache', 'object-sync-for-salesforce' );
+			}
 
-		// display contact summary if there are any contacts.
-		if ( 0 < absint( $contacts['data']['totalSize'] ) ) {
-			$contacts_apicall_summary = sprintf(
-				// translators: 1) $contacts['data']['totalSize'] is the number of items loaded, 2) $contacts['data']['records'][0]['attributes']['type'] is the name of the Salesforce object, 3) $contacts_is_cached is the "They are/are not cached, and/but" line, 4) $contacts_from_cache is the "they were/were not loaded from the cache" line, 5) is the "this request did/did not require refreshing the Salesforce token" line.
-				esc_html__( 'Salesforce successfully returned %1$s %2$s records. %3$s %4$s. %5$s.', 'object-sync-for-salesforce' ),
-				absint( $contacts['data']['totalSize'] ),
-				esc_html( $contacts['data']['records'][0]['attributes']['type'] ),
-				$contacts_is_cached,
-				$contacts_from_cache,
-				$contacts_refreshed_token
-			);
-		} else {
-			$contacts_apicall_summary = '';
+			if ( true === $contacts['is_redo'] ) {
+				$contacts_refreshed_token = esc_html__( 'This request did require refreshing the Salesforce token', 'object-sync-for-salesforce' );
+			} else {
+				$contacts_refreshed_token = esc_html__( 'This request did not require refreshing the Salesforce token', 'object-sync-for-salesforce' );
+			}
+
+			// display contact summary if there are any contacts.
+			if ( 0 < absint( $contacts['data']['totalSize'] ) ) {
+				$contacts_apicall_summary = sprintf(
+					// translators: 1) $contacts['data']['totalSize'] is the number of items loaded, 2) $contacts['data']['records'][0]['attributes']['type'] is the name of the Salesforce object, 3) $contacts_is_cached is the "They are/are not cached, and/but" line, 4) $contacts_from_cache is the "they were/were not loaded from the cache" line, 5) is the "this request did/did not require refreshing the Salesforce token" line.
+					esc_html__( 'Salesforce successfully returned %1$s %2$s records. %3$s %4$s. %5$s.', 'object-sync-for-salesforce' ),
+					absint( $contacts['data']['totalSize'] ),
+					esc_html( $contacts['data']['records'][0]['attributes']['type'] ),
+					$contacts_is_cached,
+					$contacts_from_cache,
+					$contacts_refreshed_token
+				);
+			} else {
+				$contacts_apicall_summary = '';
+			}
 		}
 
 		require_once plugin_dir_path( $this->file ) . '/templates/admin/status.php';

--- a/templates/admin/status.php
+++ b/templates/admin/status.php
@@ -32,7 +32,7 @@
 </p>
 
 <h3><?php echo esc_html__( 'Test Salesforce API Call', 'object-sync-for-salesforce' ); ?></h3>
-<?php if ( '' !== $contacts_apicall_summary ) : ?>
+<?php if ( '' !== $contacts_apicall_summary && isset( $contacts['data']['records'] ) ) : ?>
 	<table class="widefat striped">
 		<thead>
 			<summary>
@@ -52,6 +52,8 @@
 			<?php } ?>
 		</tbody>
 	</table>
+<?php elseif ( '' !== $contacts_apicall_summary ) : ?>
+	<p><?php echo wp_kses_post( $contacts_apicall_summary ); ?></p>
 <?php endif; ?>
 
 <p><small>


### PR DESCRIPTION
## What does this Pull Request do?

In some cases when the API authorization has expired, the plugin does not detect that this has happened and so it still tries to load the demo 100 contacts from Salesforce. This pull request checks to make sure there is a success code on that API call, and that there are `records` returned.

## How do I test this Pull Request?

- check the Authorize page in a scenario when the connection has expired
- check it when the connection is working properly