### PR TITLE
Setting the plugin's Debug Mode enables debug logging, regardless of other log settings.

### DIFF
--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1004,7 +1004,7 @@ class Object_Sync_Sf_Admin {
 			'args'     => array(
 				'type'     => 'checkbox',
 				'validate' => 'sanitize_text_field',
-				'desc'     => __( 'If logging is enabled, debug mode activates logging for plugin events like Salesforce API requests and WordPress data operations. This can create a lot of log entries; it is not recommended to use it long-term in a production environment.', 'object-sync-for-salesforce' ),
+				'desc'     => __( 'Debug mode activates logging for plugin events like Salesforce API requests and WordPress data operations. This can create a lot of log entries; it is not recommended to use it long-term in a production environment.', 'object-sync-for-salesforce' ),
 				'constant' => '',
 			),
 		);
@@ -1200,7 +1200,7 @@ class Object_Sync_Sf_Admin {
 				'args'     => array(
 					'type'     => 'checkbox',
 					'validate' => 'absint',
-					'desc'     => '',
+					'desc'     => __( 'This determines whether to create plugin log events in standard operation. If Debug Mode is enabled in the plugin settings, logging will occur regardless of this setting.', 'object-sync-for-salesforce' ),
 					'constant' => '',
 				),
 			),
@@ -1316,7 +1316,7 @@ class Object_Sync_Sf_Admin {
 				'args'     => array(
 					'type'     => 'checkboxes',
 					'validate' => 'sanitize_validate_text',
-					'desc'     => __( 'These are the triggers to log. When the plugin is in debug mode (see the settings tag), all triggers will be considered to be triggers to log, even if they are not checked here.', 'object-sync-for-salesforce' ),
+					'desc'     => __( 'These are the triggers to log. When the plugin is in debug mode (see the settings tab), all triggers will be considered to be triggers to log, even if they are not checked here.', 'object-sync-for-salesforce' ),
 					'items'    => array(
 						$this->mappings->sync_wordpress_create => array(
 							'text' => __( 'WordPress Create', 'object-sync-for-salesforce' ),
@@ -1492,7 +1492,7 @@ class Object_Sync_Sf_Admin {
 			),
 			'data_save_partial'       => array(
 				'condition'   => isset( $get_data['data_saved'] ) && 'partial' === $get_data['data_saved'],
-				'message'     => __( 'This data was partially successfully saved. This means some of the data was unable to save. If you have enabled logging in the plugin settings, there should be a log entry with further details.', 'object-sync-for-salesforce' ),
+				'message'     => __( 'This data was partially successfully saved. This means some of the data was unable to save. If you have enabled logging or debug mode in the plugin settings, there should be a log entry with further details.', 'object-sync-for-salesforce' ),
 				'type'        => 'error',
 				'dismissible' => true,
 			),

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -1004,7 +1004,7 @@ class Object_Sync_Sf_Admin {
 			'args'     => array(
 				'type'     => 'checkbox',
 				'validate' => 'sanitize_text_field',
-				'desc'     => __( 'Debug mode can, combined with the Log Settings, log things like Salesforce API requests. It can create a lot of entries if enabled; it is not recommended to use it in a production environment.', 'object-sync-for-salesforce' ),
+				'desc'     => __( 'If logging is enabled, debug mode activates logging for plugin events like Salesforce API requests and WordPress data operations. This can create a lot of log entries; it is not recommended to use it long-term in a production environment.', 'object-sync-for-salesforce' ),
 				'constant' => '',
 			),
 		);
@@ -1212,7 +1212,7 @@ class Object_Sync_Sf_Admin {
 				'args'     => array(
 					'type'     => 'checkboxes',
 					'validate' => 'sanitize_validate_text',
-					'desc'     => __( 'These are the statuses to log', 'object-sync-for-salesforce' ),
+					'desc'     => '',
 					'items'    => array(
 						'error'   => array(
 							'text' => __( 'Error', 'object-sync-for-salesforce' ),
@@ -1227,11 +1227,6 @@ class Object_Sync_Sf_Admin {
 						'notice'  => array(
 							'text' => __( 'Notice', 'object-sync-for-salesforce' ),
 							'id'   => 'notice',
-							'desc' => '',
-						),
-						'debug'   => array(
-							'text' => __( 'Debug', 'object-sync-for-salesforce' ),
-							'id'   => 'debug',
 							'desc' => '',
 						),
 					),
@@ -1321,7 +1316,7 @@ class Object_Sync_Sf_Admin {
 				'args'     => array(
 					'type'     => 'checkboxes',
 					'validate' => 'sanitize_validate_text',
-					'desc'     => __( 'These are the triggers to log', 'object-sync-for-salesforce' ),
+					'desc'     => __( 'These are the triggers to log. When the plugin is in debug mode (see the settings tag), all triggers will be considered to be triggers to log, even if they are not checked here.', 'object-sync-for-salesforce' ),
 					'items'    => array(
 						$this->mappings->sync_wordpress_create => array(
 							'text' => __( 'WordPress Create', 'object-sync-for-salesforce' ),
@@ -2234,9 +2229,10 @@ class Object_Sync_Sf_Admin {
 	 * @param array $args is the arguments to create the checkboxes.
 	 */
 	public function display_checkboxes( $args ) {
-		$type    = 'checkbox';
-		$name    = $args['name'];
-		$options = get_option( $name, array() );
+		$type       = 'checkbox';
+		$name       = $args['name'];
+		$options    = get_option( $name, array() );
+		$group_desc = $args['desc'];
 		foreach ( $args['items'] as $key => $value ) {
 			$text    = $value['text'];
 			$id      = $value['id'];
@@ -2264,6 +2260,12 @@ class Object_Sync_Sf_Admin {
 					esc_html( $desc )
 				);
 			}
+		}
+		if ( '' !== $group_desc ) {
+			echo sprintf(
+				'<p class="description">%1$s</p>',
+				esc_html( $group_desc )
+			);
 		}
 	}
 

--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -104,25 +104,8 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 	 * Initialize. This creates a schedule for pruning logs, and also the custom content type
 	 */
 	public function init() {
+		$this->configure_debugging();
 		if ( true === $this->enabled ) {
-
-			// set debug log status based on the plugin's debug mode setting.
-			if ( true === $this->debug ) {
-				$this->statuses_to_log[] = 'debug';
-				$this->enabled           = true;
-			} else {
-				if ( in_array( 'debug', $this->statuses_to_log, true ) ) {
-					$delete_value          = 'debug';
-					$this->statuses_to_log = array_filter(
-						$this->statuses_to_log,
-						function( $e ) use ( $delete_value ) {
-							return ( $e !== $delete_value );
-						}
-					);
-					update_option( $this->option_prefix . 'statuses_to_log', $this->statuses_to_log );
-				}
-			}
-
 			add_filter( 'cron_schedules', array( $this, 'add_prune_interval' ) );
 			add_filter( 'wp_log_types', array( $this, 'set_log_types' ), 10, 1 );
 			add_filter( 'wp_logging_should_we_prune', array( $this, 'set_prune_option' ), 10, 1 );
@@ -151,6 +134,28 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 			add_action( 'update_option_' . $this->option_prefix . 'logs_how_often_number', array( $this, 'check_log_schedule' ), 10, 3 );
 
 			$this->save_log_schedule();
+		}
+	}
+
+	/**
+	 * Configure log settings based on debug status.
+	 */
+	private function configure_debugging() {
+		// set debug log status based on the plugin's debug mode setting.
+		if ( true === $this->debug ) {
+			$this->statuses_to_log[] = 'debug';
+			$this->enabled           = true;
+		} else {
+			if ( in_array( 'debug', $this->statuses_to_log, true ) ) {
+				$delete_value          = 'debug';
+				$this->statuses_to_log = array_filter(
+					$this->statuses_to_log,
+					function( $e ) use ( $delete_value ) {
+						return ( $e !== $delete_value );
+					}
+				);
+				update_option( $this->option_prefix . 'statuses_to_log', $this->statuses_to_log );
+			}
 		}
 	}
 

--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -508,14 +508,6 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 			$title = $title_or_params;
 		}
 
-		if ( ! is_array( $this->statuses_to_log ) ) {
-			if ( $status === $this->statuses_to_log ) {
-				$this->add( $title, $message, $parent );
-			} else {
-				return;
-			}
-		}
-
 		if ( true === $this->enabled && in_array( $status, $this->statuses_to_log, true ) ) {
 			$triggers_to_log = maybe_unserialize( get_option( $this->option_prefix . 'triggers_to_log', array() ) );
 			if ( in_array( $trigger, $triggers_to_log, true ) || 0 === $trigger ) {

--- a/docs/adding-settings.md
+++ b/docs/adding-settings.md
@@ -125,7 +125,7 @@ function add_content( $content_after = null, $tab ) {
 
 As of version 2.2.0, the requirement to set the REST API version that the plugin uses to send requests to Salesforce has been removed from the plugin interface. For most users this is an improvement; it removes the potential for old API versions to cause problems with new functionality, and removes the potential for users to unintentionally use API versions that are no longer active.
 
-For developers who many rely on version-specific API functionality from Salesforce and are able to deal with potential consequences, the plugin does include a filter with the ability to override the REST API version for all plugin API requests. You might do this if you use custom functionality that depends on an older or newer version of the API than is supported by the plugin.
+For developers who may rely on version-specific API functionality from Salesforce and are able to deal with potential consequences, the plugin does include a filter with the ability to override the REST API version for all plugin API requests. You might do this if you use custom functionality that depends on an older or newer version of the API than is supported by the plugin.
 
 #### Code example
 

--- a/docs/initial-setup.md
+++ b/docs/initial-setup.md
@@ -81,7 +81,7 @@ Go to the Settings tab for the plugin. It is the default URL that opens when you
 10. Pull Query Record Limit: Limit the number of records that can be pulled from Salesforce in a single query.
 11. Pull Throttle (In Seconds): This plugin starts with 5 seconds, but you can change it based on your server's needs.
 12. Enable the Salesforce SOAP API?: In addition to its REST API, Salesforce maintains a SOAP-based API. Some functionality, namely record merges, can only be accessed through this API. If you need to detect these kind of events, enable the SOAP API with this field. If you do, you will see an optional Path to SOAP WSDL File field where you can override the default WSDL file.
-13. Debug Mode: If logging is enabled, debug mode activates logging for plugin events like Salesforce API requests and WordPress data operations. This can create a lot of log entries; it is not recommended to use it long-term in a production environment.
+13. Debug Mode: Debug mode activates logging for plugin events like Salesforce API requests and WordPress data operations. This can create a lot of log entries; it is not recommended to use it long-term in a production environment.
 14. Delete Plugin Data on Uninstall?: When the plugin is uninstalled, by default it does not remove any data. If you want it to remove its custom tables, scheduling tasks, log post type, capability, and option values, check this box before you uninstall it.
 
 Save the settings. If the values required are set, you'll see a message that says "Salesforce needs to be authorized to connect to this website. Use the Authorize tab to connect." You can use that link for the next steps.

--- a/docs/initial-setup.md
+++ b/docs/initial-setup.md
@@ -69,21 +69,20 @@ After you save these settings, click Continue and you'll see the values for your
 
 Go to the Settings tab for the plugin. It is the default URL that opens when you click Salesforce in the main Settings menu. Enter the values based on your Salesforce environment.
 
-1. Consumer Key: (your value from above)
-2. Consumer Secret: (your value from above)
+1. Consumer Key: (your value from Salesforce)
+2. Consumer Secret: (your value from Salesforce)
 3. Callback URL: `https://<your site>/wp-admin/options-general.php?page=object-sync-salesforce-admin&tab=authorize`
 4. Login Base URL: For most Salesforce environments, you can use `https://test.salesforce.com` for sandbox, and `https://login.salesforce.com` for production.
 5. Authorize URL Path: The plugin starts with a default of `/services/oauth2/authorize`. You should generally not have to change this.
 6. Token URL Path: The plugin starts with a default of `/services/oauth2/token`. You should generally not have to change this.
-7. Salesforce API Version: You should generally use the latest version your install has access to. This plugin starts with 52.0, but once it is authenticated the text field will be replaced with a dropdown of your available versions from which you can choose.
-8. Limit Salesforce Objects: These allow you to indicate whether Salesforce should relate to objects that can't be triggered or updated via the API. Generally it's a good idea to have these boxes checked to avoid errors.
-9. Salesforce Field Display Value: When mapping Salesforce fields, you can choose whether the plugin will display a field's Field Label (possibly a more user friendly value) or the API Name (which is always unique). Neither choice changes how the plugin functions on the back end, but making a choice can sometimes make the mapping choices easier to find.
-10. Prevent Duplicate Field Mapping?: This checkbox allows you to prevent any WordPress or Salesforce field from being added to a fieldmap more than once. It does this by graying out any field once it has been selected.
-11. Pull Query Record Limit: Limit the number of records that can be pulled from Salesforce in a single query.
-12. Pull Throttle (In Seconds): This plugin starts with 5 seconds, but you can change it based on your server's needs.
-13. Enable the Salesforce SOAP API?: In addition to its REST API, Salesforce maintains a SOAP-based API. Some functionality, namely record merges, can only be accessed through this API. If you need to detect these kind of events, enable the SOAP API with this field. If you do, you will see an optional Path to SOAP WSDL File field where you can override the default WSDL file.
-14. Debug Mode: This won't do anything until after the plugin has been authorized, but once it has you can use it to see more information about what the API is doing. **Don't check this in a production environment.**
-15. Delete Plugin Data on Uninstall?: When the plugin is uninstalled, by default it does not remove any data. If you want it to remove its custom tables, scheduling tasks, log post type, capability, and option values, check this box before you uninstall it.
+7. Limit Salesforce Objects: These allow you to indicate whether Salesforce should relate to objects that can't be triggered or updated via the API. Generally it's a good idea to have these boxes checked to avoid errors.
+8. Salesforce Field Display Value: When mapping Salesforce fields, you can choose whether the plugin will display a field's Field Label (possibly a more user friendly value) or the API Name (which is always unique). Neither choice changes how the plugin functions on the back end, but making a choice can sometimes make the mapping choices easier to find.
+9. Prevent Duplicate Field Mapping?: This checkbox allows you to prevent any WordPress or Salesforce field from being added to a fieldmap more than once. It does this by graying out any field once it has been selected.
+10. Pull Query Record Limit: Limit the number of records that can be pulled from Salesforce in a single query.
+11. Pull Throttle (In Seconds): This plugin starts with 5 seconds, but you can change it based on your server's needs.
+12. Enable the Salesforce SOAP API?: In addition to its REST API, Salesforce maintains a SOAP-based API. Some functionality, namely record merges, can only be accessed through this API. If you need to detect these kind of events, enable the SOAP API with this field. If you do, you will see an optional Path to SOAP WSDL File field where you can override the default WSDL file.
+13. Debug Mode: If logging is enabled, debug mode activates logging for plugin events like Salesforce API requests and WordPress data operations. This can create a lot of log entries; it is not recommended to use it long-term in a production environment.
+14. Delete Plugin Data on Uninstall?: When the plugin is uninstalled, by default it does not remove any data. If you want it to remove its custom tables, scheduling tasks, log post type, capability, and option values, check this box before you uninstall it.
 
 Save the settings. If the values required are set, you'll see a message that says "Salesforce needs to be authorized to connect to this website. Use the Authorize tab to connect." You can use that link for the next steps.
 
@@ -99,7 +98,6 @@ Supported constant names are:
 4. OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL
 5. OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH
 6. OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH
-7. OBJECT_SYNC_SF_SALESFORCE_API_VERSION
 
 Set them in `wp-config.php` like this:
 
@@ -108,7 +106,6 @@ define('OBJECT_SYNC_SF_SALESFORCE_CONSUMER_KEY', 'valuefromsalesforce');
 define('OBJECT_SYNC_SF_SALESFORCE_CONSUMER_SECRET', 'valuefromsalesforce');
 define('OBJECT_SYNC_SF_SALESFORCE_CALLBACK_URL', 'https://<your site>/wp-admin/options-general.php?page=object-sync-salesforce-admin&tab=authorize');
 define('OBJECT_SYNC_SF_SALESFORCE_LOGIN_BASE_URL', 'https://test.salesforce.com');
-define('OBJECT_SYNC_SF_SALESFORCE_API_VERSION', '52.0');
 define('OBJECT_SYNC_SF_SALESFORCE_AUTHORIZE_URL_PATH', '/services/oauth2/authorize');
 define('OBJECT_SYNC_SF_SALESFORCE_TOKEN_URL_PATH', '/services/oauth2/token');
 ```
@@ -128,5 +125,4 @@ Steps:
 3. Salesforce will ask you to allow access to the app (in these instructions, the name is WordPress Example), and will show you what permissions it needs.
 4. Click Allow.
 5. You'll be redirected back to WordPress. Don't do anything until you see a message that says "Salesforce is successfully authenticated."
-6. The tab will display a "Disconnect from Salesforce" button which you can click at any time, and will also show a bit of basic information about your Salesforce environment (the available API versions and a basic table of Contacts.)
-7. If you'd like to use a different Salesforce API version, go back to the Settings tab and pick your desired version from the dropdown.
+6. The tab will display a "Disconnect from Salesforce" button which you can click at any time, and will also show a bit of basic information about your Salesforce environment.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -23,7 +23,6 @@ If you load the plugin's Settings screen and you do not see an Authorize tab, th
 - Login Base URL
 - Authorize URL Path
 - Token URL Path
-- Salesforce API Version
 
 ### Error: invalid_client_id
 


### PR DESCRIPTION
## What does this Pull Request do?
Previously, when the plugin was in debug mode, users also had to enable debug log messages. This is an unnecessary amount of configuration. Now, enabling debug mode enables all debug logging, regardless of the other log settings.

## How do I test this Pull Request?

- enable Debug Mode; watch for log entries
- disable Debug Mode; the plugin should respect the other log settings for the plugin.