### PR TITLE
 Fix undefined WP_Query method preventing prematch

### DIFF
--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -1375,7 +1375,7 @@ class Object_Sync_Sf_WordPress {
 					),
 				);
 				$match_query        = new $method( $args );
-				$posts              = $match_query->get_results();
+				$posts              = $match_query->get_posts();
 			} else {
 				$posts = $method( $args );
 			}


### PR DESCRIPTION
## What does this Pull Request do?

Fixes undefined WP_Query method bug #484 

## How do I test this Pull Request?
1. Setup a mapping that Prematches on a metavalue for a metakey ( e.g. "salesforce_id" ).
2. Create a post and add that postmeta key.
3. Initiate a sync with a Salesforce record that has a value that matches the metavalue of a pre-existing post.
4. Check that the new row created in `wp_2020_object_sync_sf_object_map` has the same post_id as the pre-existing post's ID, and a new/duplicate post is not created.