### PR TITLE
Fix the method that creates dates on new events for The Events Calendar. Thanks to WordPress users @adamsmm and @joelmcdwebworks.

### DIFF
--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -2633,7 +2633,7 @@ class Object_Sync_Sf_WordPress {
 			$dates                                      = array();
 			$date_type                                  = ucfirst( $type );
 			$timestamp                                  = strtotime( $date );
-			$dates[ 'Event' . $date_type . 'Date' ]     = $timestamp;
+			$dates[ 'Event' . $date_type . 'Date' ]     = gmdate( Tribe__Date_Utils::DBDATEFORMAT, $timestamp );
 			$dates[ 'Event' . $date_type . 'Hour' ]     = gmdate( Tribe__Date_Utils::HOURFORMAT, $timestamp );
 			$dates[ 'Event' . $date_type . 'Minute' ]   = gmdate( Tribe__Date_Utils::MINUTEFORMAT, $timestamp );
 			$dates[ 'Event' . $date_type . 'Meridian' ] = gmdate( Tribe__Date_Utils::MERIDIANFORMAT, $timestamp );


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #487, in which new event post types, associated with The Events Calendar, created in WordPress from Salesforce data, have incorrect date values. See especially [this forum post](https://wordpress.org/support/topic/matching-date-time-format/), and also [this one](https://wordpress.org/support/topic/syncing-with-the-events-calendar/).

## How do I test this Pull Request?

- Set up a fieldmap that sends a date/time from Salesforce to a date/time for The Events Calendar
- The Events Calendar plugin is correctly saving the date.