### PR TITLE
Use the WordPress install's database prefix with the capabilities field. Thanks to WordPress user @dhartendorp for the report.

### DIFF
--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -964,7 +964,7 @@ class Object_Sync_Sf_Mapping {
 				// Is the field in WordPress an array, if we unserialize it? Salesforce wants it to be an imploded string.
 				if ( is_array( maybe_unserialize( $object[ $wordpress_field ] ) ) ) {
 					// if the WordPress field is a list of capabilities (the source field is wp_capabilities), we need to get the array keys from WordPress to send them to Salesforce.
-					if ( 'wp_capabilities' === $wordpress_field ) {
+					if ( $this->wpdb->prefix . 'capabilities' === $wordpress_field ) {
 						$object[ $wordpress_field ] = implode( $this->array_delimiter, array_keys( $object[ $wordpress_field ] ) );
 					} else {
 						$object[ $wordpress_field ] = implode( $this->array_delimiter, $object[ $wordpress_field ] );
@@ -1055,7 +1055,7 @@ class Object_Sync_Sf_Mapping {
 					if ( in_array( $salesforce_field_type, $this->array_types_from_salesforce, true ) ) {
 						$object[ $salesforce_field ] = explode( $this->array_delimiter, $object[ $salesforce_field ] );
 						// if the WordPress field is a list of capabilities (the destination field is wp_capabilities), we need to set the array for WordPress to save it.
-						if ( 'wp_capabilities' === $wordpress_field ) {
+						if ( $this->wpdb->prefix . 'capabilities' === $wordpress_field ) {
 							$capabilities = array();
 							foreach ( $object[ $salesforce_field ] as $capability ) {
 								$capabilities[ $capability ] = true;


### PR DESCRIPTION
## What does this Pull Request do?

This fixes #500 by using `$this->wpdb->prefix . 'capabilities'` instead of `wp_capabilities`.

## How do I test this Pull Request?

- Map a capabilities field with a custom prefix
- Map a capabilities field without a custom prefix
