### PR TITLE
Add links to edit the WordPress and/or Salesforce record on the Mapping Errors tab

### DIFF
--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -2647,4 +2647,46 @@ class Object_Sync_Sf_WordPress {
 		return $content;
 	}
 
+	/**
+	 * Generate an edit link for the WordPress record.
+	 *
+	 * @param string $object_type the type of WordPress object.
+	 * @param int    $wordpress_id the ID of the WordPress object.
+	 *
+	 * @return string $edit_link
+	 */
+	public function object_edit_link( $object_type, $wordpress_id ) {
+		$edit_link = '';
+		if ( 'user' === $object_type ) {
+			$edit_link = get_edit_user_link( $wordpress_id );
+		} elseif ( 'post' === $object_type || 'page' === $object_type || 'attachment' === $object_type ) {
+			$edit_link = get_edit_post_link( $wordpress_id );
+		} elseif ( 'category' === $object_type || 'tag' === $object_type || 'post_tag' === $object_type ) {
+			$edit_link = get_edit_term_link( $wordpress_id );
+		} elseif ( 'comment' === $object_type ) {
+			$edit_link = get_edit_comment_link( $wordpress_id );
+		} else { // This is for custom post types.
+			$edit_link = get_edit_post_link( $wordpress_id );
+		} // End if() statement.
+		return $edit_link;
+	}
+
+	/**
+	 * Generate a delete link for the WordPress record.
+	 *
+	 * @param string $object_type the type of WordPress object.
+	 * @param int    $wordpress_id the ID of the WordPress object.
+	 *
+	 * @return string $delete_link
+	 */
+	public function object_delete_link( $object_type, $wordpress_id ) {
+		$delete_link = '';
+		if ( 'post' === $object_type || 'page' === $object_type || 'attachment' === $object_type ) {
+			$delete_link = get_delete_post_link( $wordpress_id );
+		} else { // This is for custom post types.
+			$delete_link = get_delete_post_link( $wordpress_id );
+		} // End if() statement.
+		return $delete_link;
+	}
+
 }

--- a/templates/admin/mapping-errors-edit.php
+++ b/templates/admin/mapping-errors-edit.php
@@ -133,3 +133,32 @@
 		</li>
 	</ul>
 </div>
+
+<div class="object_map_data">
+	<h2><?php echo esc_html__( 'Data Access Links', 'object-sync-for-salesforce' ); ?></h2>
+	<p><?php echo esc_html__( 'This section will change based on what data is available to the plugin. If it is able to detect a valid WordPress or Salesforce ID, it will link to that record. If the record does not exist, there will be no link.', 'object-sync-for-salesforce' ); ?></p>
+	<ul>
+	<?php if ( '' !== esc_url( $this->wordpress->object_edit_link( $map_row['wordpress_object'], $map_row['wordpress_id'] ) ) ) : ?>
+		<li>
+			<span class="dashicons dashicons-edit-large"></span>
+			<a href="<?php echo esc_url( $this->wordpress->object_edit_link( $map_row['wordpress_object'], $map_row['wordpress_id'] ) ); ?>">
+				<?php
+				echo sprintf(
+					// translators: placeholder is the WordPress object type.
+					esc_html__( 'Edit WordPress %1$s', 'object-sync-for-salesforce' ),
+					esc_attr( ucfirst( $map_row['wordpress_object'] ) )
+				);
+				?>
+			</a>
+		</li>
+	<?php endif; ?>
+	<?php if ( substr( $map_row['salesforce_id'], 0, 7 ) !== 'tmp_sf_' ) : ?>
+		<li>
+			<span class="dashicons dashicons-edit-large"></span>
+			<a href="<?php echo esc_url( $this->salesforce['sfapi']->get_instance_url() . '/' . $map_row['salesforce_id'] ); ?>">
+				<?php echo esc_html__( 'Edit Salesforce Object', 'object-sync-for-salesforce' ); ?>
+			</a>
+		</li>
+	<?php endif; ?>
+	</ul>
+</div>

--- a/templates/admin/mapping-errors.php
+++ b/templates/admin/mapping-errors.php
@@ -122,11 +122,37 @@
 					</div>
 					<div class="row-actions visible">
 						<span class="edit">
-						<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $mapping_error['id'] ) ); ?>"><?php echo esc_html__( 'Edit', 'object-sync-for-salesforce' ); ?></a> | 
+						<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=edit&id=' . $mapping_error['id'] ) ); ?>"><?php echo esc_html__( 'Edit Mapping Object', 'object-sync-for-salesforce' ); ?></a> | 
 						</span>
+						<?php if ( '' !== esc_url( $this->wordpress->object_edit_link( $mapping_error['wordpress_object'], $mapping_error['wordpress_id'] ) ) ) : ?>
+							<span class="edit">
+							<a href="<?php echo esc_url( $this->wordpress->object_edit_link( $mapping_error['wordpress_object'], $mapping_error['wordpress_id'] ) ); ?>">
+								<?php
+								echo sprintf(
+									// translators: placeholder is the WordPress object type.
+									esc_html__( 'Edit %1$s', 'object-sync-for-salesforce' ),
+									esc_attr( ucfirst( $mapping_error['wordpress_object'] ) )
+								);
+								?>
+							</a> | 
+							</span>
+						<?php endif; ?>
 						<span class="delete">
-						<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $mapping_error['id'] ) ); ?>"><?php echo esc_html__( 'Delete', 'object-sync-for-salesforce' ); ?></a>
+						<a href="<?php echo esc_url( get_admin_url( null, 'options-general.php?page=object-sync-salesforce-admin&tab=mapping_errors&method=delete&id=' . $mapping_error['id'] ) ); ?>"><?php echo esc_html__( 'Delete Mapping Object', 'object-sync-for-salesforce' ); ?></a>
 						</span>
+						<?php if ( '' !== esc_url( $this->wordpress->object_delete_link( $mapping_error['wordpress_object'], $mapping_error['wordpress_id'] ) ) ) : ?>
+							<span class="delete">
+							<a href="<?php echo esc_url( $this->wordpress->object_delete_link( $mapping_error['wordpress_object'], $mapping_error['wordpress_id'] ) ); ?>">
+								<?php
+								echo sprintf(
+									// translators: placeholder is the WordPress object type.
+									esc_html__( 'Delete %1$s', 'object-sync-for-salesforce' ),
+									esc_attr( ucfirst( $mapping_error['wordpress_object'] ) )
+								);
+								?>
+							</a> | 
+							</span>
+						<?php endif; ?>
 					</div>
 					<button type="button" class="toggle-row"><span class="screen-reader-text">Show more details</span></button>
 				</td>


### PR DESCRIPTION
## What does this Pull Request do?

When the Mapping Errors tab is present, provide direct links to edit the WordPress and/or Salesforce record, depending on which ones exist. This applies both to the list of all errors, and to the individual error record. This closes #479.

## How do I test this Pull Request?

- generate some errors
- see the edit links