### PR TITLE
Added filter to short-circuit API calls to Salesforce

### DIFF
--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -492,11 +492,12 @@ class Object_Sync_Sf_Salesforce {
 		 *
 		 * @since x.x.x
 		 *
-		 * @param string $url     Path to make request from.
-		 * @param array  $data    The request body.
-		 * @param array  $headers Request headers to send as name => value.
-		 * @param string $method  Method to initiate the call, such as GET or POST. Defaults to GET.
-		 * @param array  $options This is the options array from the api_http_request method.
+		 * @param null|array $check   Whether to short-circuit the HTTP request. Default null.
+		 * @param string     $url     Path to make request from.
+		 * @param array      $data    The request body.
+		 * @param array      $headers Request headers to send as name => value.
+		 * @param string     $method  Method to initiate the call, such as GET or POST. Defaults to GET.
+		 * @param array      $options This is the options array from the api_http_request method.
 		 */
 		$check = apply_filters( $this->option_prefix . 'http_request', null, $url, $data, $headers, $method, $options );
 

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -484,6 +484,26 @@ class Object_Sync_Sf_Salesforce {
 	protected function http_request( $url, $data, $headers = array(), $method = 'GET', $options = array() ) {
 		// Build the request, including path and headers. Internal use.
 
+		/**
+		 * Short-circuits the return value of an HTTP API call.
+		 *
+		 * This allows other plugins to communicate with the Salesforce API on behalf of
+		 * Object Sync for Salesforce, for example by using the WordPress HTTP API.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $url     Path to make request from.
+		 * @param array  $data    The request body.
+		 * @param array  $headers Request headers to send as name => value.
+		 * @param string $method  Method to initiate the call, such as GET or POST. Defaults to GET.
+		 * @param array  $options This is the options array from the api_http_request method.
+		 */
+		$check = apply_filters( $this->option_prefix . 'http_request', null, $url, $data, $headers, $method, $options );
+
+		if ( null !== $check ) {
+			return $check;
+		}
+
 		/*
 		 * Note: curl is used because wp_remote_get, wp_remote_post, wp_remote_request don't work. Salesforce returns various errors.
 		 * todo: There is a GitHub branch attempting with the goal of addressing this: https://github.com/MinnPost/object-sync-for-salesforce/issues/94

--- a/classes/class-object-sync-sf-salesforce.php
+++ b/classes/class-object-sync-sf-salesforce.php
@@ -490,7 +490,7 @@ class Object_Sync_Sf_Salesforce {
 		 * This allows other plugins to communicate with the Salesforce API on behalf of
 		 * Object Sync for Salesforce, for example by using the WordPress HTTP API.
 		 *
-		 * @since x.x.x
+		 * @since 2.2.7
 		 *
 		 * @param null|array $check   Whether to short-circuit the HTTP request. Default null.
 		 * @param string     $url     Path to make request from.


### PR DESCRIPTION
## What does this Pull Request do?

This PR adds a filter to the `http_request()` function in class `Object_Sync_Sf_Salesforce` to allow short-circuiting the API call and response.

The goal of the PR is to help create a tighter integration with WP Fusion (https://github.com/verygoodplugins/wp-fusion-lite/ and https://wpfusion.com/).

The logic follows what already exists in WP core, for example with `update_metadata()`: https://github.com/WordPress/WordPress/blob/master/wp-includes/meta.php#L233

With this filter in place, we will be able to:

- Route outgoing API calls through WP Fusion (and the WordPress HTTP API / `wp_remote_request()`)
- Use WP Fusion's built in error handling, logging, and token refresh capabilities for Object Sync API calls
- Detect potential data collision (for example if WP Fusion is about to operate on the same record)
- Automatically configure Object Sync using the Salesforce client ID and tokens already managed by WP Fusion

We're excited to create a deeper integration between WP Fusion and Object Sync for Salesforce, and this change would allow us to tie the two plugins together much more closely than is currently possible.

Thanks for your consideration :)
