### PR TITLE
Fix php 8.2 dynamic properties

### DIFF
--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -77,6 +77,13 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 	public $debug;
 
 	/**
+	 * The name of the capability used when registering the logging post type.
+	 *
+	 * @var string
+	 */
+	public $capability;
+
+	/**
 	 * Constructor for logging class
 	 */
 	public function __construct() {

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -245,6 +245,69 @@ class Object_Sync_Sf_Mapping {
 	public $debug;
 
 	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_off_v1;
+
+	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_wordpress_create_v1;
+
+	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_wordpress_update_v1;
+
+	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_wordpress_delete_v1;
+
+	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_sf_create_v1;
+
+	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_sf_update_v1;
+
+	/**
+	 * Deprecated hex parameter which defines when syncing should occur on each field map.
+	 *
+	 * @var int
+	 */
+	public $sync_sf_delete_v1;
+
+	/**
+	 * Deprecated hex event values.
+	 *
+	 * @var array
+	 */
+	public $wordpress_events_v1;
+
+	/**
+	 * Deprecated hex event values.
+	 *
+	 * @var array
+	 */
+	public $salesforce_events_v1;
+
+	/**
 	 * Constructor for mapping class
 	 */
 	public function __construct() {


### PR DESCRIPTION
## This PR adds property declarations to classes in order to clean up some of the deprecation warnings that have cropped up after upgrading to PHP 8.2.

## How do I test this Pull Request?

Load the plugin and view the error log. This PR will clean up the deprecation notices for dynamic properties. There are still some other deprecations for other things, but I wanted to limit the scope of this PR and also make sure I didn't break anything :)
