### PR TITLE
Prevent error on blank WordPress install caused by a string instead of an integer. Thanks to GitHub user @federicojacobi for the pull request.

### DIFF
--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -384,7 +384,7 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 	public function add_prune_interval( $schedules ) {
 
 		$schedule_unit   = get_option( $this->option_prefix . 'logs_how_often_unit', '' );
-		$schedule_number = get_option( $this->option_prefix . 'logs_how_often_number', '' );
+		$schedule_number = absint( get_option( $this->option_prefix . 'logs_how_often_number', '' ) );
 		$frequency       = $this->get_schedule_frequency( $schedule_unit, $schedule_number );
 		$key             = $frequency['key'];
 		$seconds         = $frequency['seconds'];


### PR DESCRIPTION
## What does this Pull Request do?

In this particular case, `$schedule_number` must be a number because in [line 393](https://github.com/MinnPost/object-sync-for-salesforce/blob/master/classes/class-object-sync-sf-logging.php#L393) it is being multiplied. I'm not sure if it is a PHP8 thing, but you cannot multiple an int ($seconds) by a string (empty or otherwise). `$schedule_number` must be a positive int, just casting isn't enough, `absint` should cover it.

## How do I test this Pull Request?

I only noticed this on a blank WP install, if you turn logging on it'll throw a fatal as no schedules have ever been set.