### PR TITLE
Fix a couple of deprecated warnings that appear in logs in newer php versions

### DIFF
--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -1328,8 +1328,8 @@ class Object_Sync_Sf_Mapping {
 		$items_per_page        = (int) get_option( $this->option_prefix . 'errors_per_page', 50 );
 		$current_error_page    = isset( $_GET['error_page'] ) ? (int) $_GET['error_page'] : 1;
 		$offset                = ( $current_error_page * $items_per_page ) - $items_per_page;
-		$all_errors            = $this->wpdb->get_results( "SELECT * FROM ${table} WHERE salesforce_id LIKE 'tmp_sf_%' OR wordpress_id LIKE 'tmp_wp_%' OR last_sync_status = 0 LIMIT ${offset}, ${items_per_page}", ARRAY_A );
-		$errors_total          = $this->wpdb->get_var( "SELECT COUNT(`id`) FROM ${table} WHERE salesforce_id LIKE 'tmp_sf_%' OR wordpress_id LIKE 'tmp_wp_%' OR last_sync_status = 0" );
+		$all_errors            = $this->wpdb->get_results( "SELECT * FROM {$table} WHERE salesforce_id LIKE 'tmp_sf_%' OR wordpress_id LIKE 'tmp_wp_%' OR last_sync_status = 0 LIMIT {$offset}, {$items_per_page}", ARRAY_A );
+		$errors_total          = $this->wpdb->get_var( "SELECT COUNT(`id`) FROM {$table} WHERE salesforce_id LIKE 'tmp_sf_%' OR wordpress_id LIKE 'tmp_wp_%' OR last_sync_status = 0" );
 		$errors['total_pages'] = ceil( $errors_total / $items_per_page );
 		$errors['pagination']  = paginate_links(
 			array(

--- a/classes/class-object-sync-sf-queue.php
+++ b/classes/class-object-sync-sf-queue.php
@@ -171,7 +171,7 @@ class Object_Sync_Sf_Queue {
 				$minutes = 0;
 		}
 
-		$total = ${$unit} * $schedule_number;
+		$total = $$unit * $schedule_number;
 
 		return $total;
 	}


### PR DESCRIPTION
## What does this Pull Request do?
In newer versions of PHP, the log entry `Using ${var} in strings is deprecated` appears. This fixes at least some of the places where this would happen.