### PR TITLE
Add a new filter to prevent new user notifications. Also prevents some possible errors that can happen when plugin options haven't been set. Thanks to @federicojacobi for the pull request.

### DIFF
--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -95,7 +95,7 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 
 		$this->enabled         = filter_var( get_option( $this->option_prefix . 'enable_logging', false ), FILTER_VALIDATE_BOOLEAN );
 		$this->statuses_to_log = maybe_unserialize( get_option( $this->option_prefix . 'statuses_to_log', array() ) );
-		$this->statuses_to_log = empty( $this->statuses_to_log ) ? [] : $this->statuses_to_log;
+		$this->statuses_to_log = empty( $this->statuses_to_log ) ? array() : $this->statuses_to_log;
 
 		$this->schedule_name = 'wp_logging_prune_routine';
 

--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -95,6 +95,7 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 
 		$this->enabled         = filter_var( get_option( $this->option_prefix . 'enable_logging', false ), FILTER_VALIDATE_BOOLEAN );
 		$this->statuses_to_log = maybe_unserialize( get_option( $this->option_prefix . 'statuses_to_log', array() ) );
+		$this->statuses_to_log = empty( $this->statuses_to_log ) ? [] : $this->statuses_to_log;
 
 		$this->schedule_name = 'wp_logging_prune_routine';
 
@@ -516,8 +517,8 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 		}
 
 		if ( true === $this->enabled && in_array( $status, $this->statuses_to_log, true ) ) {
-			$triggers_to_log = maybe_unserialize( get_option( $this->option_prefix . 'triggers_to_log', array() ) );
-			if ( in_array( $trigger, $triggers_to_log, true ) || 0 === $trigger ) {
+			$triggers_to_log = (array) maybe_unserialize( get_option( $this->option_prefix . 'triggers_to_log', array() ) );
+			if ( 0 === $trigger || in_array( $trigger, $triggers_to_log, true ) ) {
 				$this->add( $title, $message, $parent );
 			} elseif ( is_array( $trigger ) && array_intersect( $trigger, $triggers_to_log ) ) {
 				$this->add( $title, $message, $parent );

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -135,14 +135,14 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Which events are run by WordPress
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $wordpress_events;
 
 	/**
 	 * Which events are run by Salesforce
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $salesforce_events;
 
@@ -170,14 +170,14 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * WordPress directions, including sync
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $direction_wordpress;
 
 	/**
 	 * Salesforce directions, including sync
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $direction_salesforce;
 
@@ -198,21 +198,21 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Data in Salesforce that is stored as an array
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $array_types_from_salesforce;
 
 	/**
 	 * Data in Salesforce that is stored as a date
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $date_types_from_salesforce;
 
 	/**
 	 * Data in Salesforce that is stored as an integer
 	 *
-	 * @var string
+	 * @var string[]
 	 */
 	public $int_types_from_salesforce;
 

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -135,14 +135,14 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Which events are run by WordPress
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $wordpress_events;
 
 	/**
 	 * Which events are run by Salesforce
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $salesforce_events;
 
@@ -170,14 +170,14 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * WordPress directions, including sync
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $direction_wordpress;
 
 	/**
 	 * Salesforce directions, including sync
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $direction_salesforce;
 

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -198,21 +198,21 @@ class Object_Sync_Sf_Mapping {
 	/**
 	 * Data in Salesforce that is stored as an array
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $array_types_from_salesforce;
 
 	/**
 	 * Data in Salesforce that is stored as a date
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $date_types_from_salesforce;
 
 	/**
 	 * Data in Salesforce that is stored as an integer
 	 *
-	 * @var string[]
+	 * @var array
 	 */
 	public $int_types_from_salesforce;
 

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -312,6 +312,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			// Store this request time for the throttle check.
 			$this->pull_options->set( 'last_sync', '', '', time() );
+
 			return true;
 
 		} else {
@@ -347,7 +348,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 	private function get_updated_records() {
 		$sfapi = $this->salesforce['sfapi'];
 		foreach ( $this->mappings->get_fieldmaps( null, $this->mappings->active_fieldmap_conditions ) as $salesforce_mapping ) {
-			$map_sync_triggers = $salesforce_mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping.
+			$map_sync_triggers = (array) $salesforce_mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping.
 			$type              = $salesforce_mapping['salesforce_object']; // this sets the Salesforce object type for the SOQL query.
 
 			$soql = $this->get_pull_query( $type, $salesforce_mapping );
@@ -657,7 +658,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 						$sf_sync_trigger = $this->mappings->sync_sf_update;
 					}
 					// Only queue when the record's trigger is configured for the mapping.
-					if ( isset( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) { // wp or sf crud event.
+					if ( isset( $map_sync_triggers ) && is_array( $map_sync_triggers ) && isset( $sf_sync_trigger ) && in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) { // wp or sf crud event.
 						$data = array(
 							'object_type'     => $type,
 							'object'          => $result,
@@ -776,7 +777,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 			);
 
 			// check if this is a Salesforce create event.
-			if ( in_array( $this->mappings->sync_sf_create, $salesforce_mapping['sync_triggers'], true ) ) {
+			if ( in_array( $this->mappings->sync_sf_create, (array) $salesforce_mapping['sync_triggers'], true ) ) {
 				$soql->fields['CreatedDate'] = 'CreatedDate';
 			}
 
@@ -1053,7 +1054,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		// Load all unique SF record types that we have mappings for. This results in a double loop.
 		foreach ( $this->mappings->get_fieldmaps( null, $this->mappings->active_fieldmap_conditions ) as $salesforce_mapping ) {
 
-			$map_sync_triggers = $salesforce_mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping.
+			$map_sync_triggers = (array) $salesforce_mapping['sync_triggers']; // this sets which Salesforce triggers are allowed for the mapping.
 			$type              = $salesforce_mapping['salesforce_object']; // this sets the Salesforce object type for the SOQL query.
 
 			$mappings = $this->mappings->get_fieldmaps(
@@ -1533,7 +1534,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		// delete transients that we've already processed for this Salesforce object.
 		foreach ( $transients_to_delete as $key => $value ) {
 			$fieldmap_id = $value['fieldmap']['id'];
-			$transients  = $value['transients'];
+			$transients  = (array) $value['transients'];
 			foreach ( $transients as $transient_end ) {
 				$this->sync_transients->delete( 'salesforce_pushing_' . $transient_end, '', $fieldmap_id );
 			}
@@ -2266,7 +2267,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 		$pull_allowed = true;
 
 		// if the current fieldmap does not allow create, we need to check if there is an object map for the Salesforce object Id. if not, set pull_allowed to false.
-		if ( ! in_array( $this->mappings->sync_sf_create, $map_sync_triggers, true ) ) {
+		if ( ! in_array( $this->mappings->sync_sf_create, (array) $map_sync_triggers, true ) ) {
 			$object_map = $this->mappings->load_object_maps_by_salesforce_id( $object['Id'], $salesforce_mapping );
 			if ( empty( $object_map ) ) {
 				$pull_allowed = false;

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -312,7 +312,6 @@ class Object_Sync_Sf_Salesforce_Pull {
 
 			// Store this request time for the throttle check.
 			$this->pull_options->set( 'last_sync', '', '', time() );
-
 			return true;
 
 		} else {

--- a/classes/class-object-sync-sf-salesforce-push.php
+++ b/classes/class-object-sync-sf-salesforce-push.php
@@ -746,7 +746,7 @@ class Object_Sync_Sf_Salesforce_Push {
 		// delete transients that we've already processed for this WordPress object.
 		foreach ( $transients_to_delete as $key => $value ) {
 			$fieldmap_id = $value['fieldmap']['id'];
-			$transients  = $value['transients'];
+			$transients  = (array) $value['transients'];
 			foreach ( $transients as $transient_end ) {
 				$this->sync_transients->delete( 'salesforce_pulling_' . $transient_end, '', $fieldmap_id );
 			}
@@ -1552,7 +1552,7 @@ class Object_Sync_Sf_Salesforce_Push {
 		$push_allowed = true;
 
 		// if the current fieldmap does not allow the wp create trigger, we need to check if there is an object map for the WordPress object ID. if not, set push_allowed to false.
-		if ( ! in_array( $this->mappings->sync_wordpress_create, $map_sync_triggers, true ) ) {
+		if ( ! in_array( $this->mappings->sync_wordpress_create, (array) $map_sync_triggers, true ) ) {
 			$structure               = $this->wordpress->get_wordpress_table_structure( $object_type );
 			$wordpress_id_field_name = $structure['id_field'];
 			$object_map              = array();
@@ -1567,7 +1567,7 @@ class Object_Sync_Sf_Salesforce_Push {
 		}
 
 		// check if this is a Salesforce sync trigger.
-		if ( ! in_array( $sf_sync_trigger, $map_sync_triggers, true ) ) {
+		if ( ! in_array( $sf_sync_trigger, (array) $map_sync_triggers, true ) ) {
 			$push_allowed = false;
 		}
 

--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -537,7 +537,7 @@ class Object_Sync_Sf_WordPress {
 	 * @param array  $ignore_keys Fields to ignore from the database.
 	 * @return array $all_fields The fields for the object.
 	 */
-	private function object_fields( $object_name, $id_field, $content_table, $content_methods, $meta_table, $meta_methods, $where, $ignore_keys ) {
+	private function object_fields( $object_name, $id_field, $content_table, $content_methods, $meta_table, $meta_methods, $where, $ignore_keys = [] ) {
 		// These two queries load all the fields from the specified object unless they have been specified as ignore fields.
 		// They also load the fields that are meta_keys from the specified object's meta table.
 		// Maybe a box for a custom query, since custom fields get done in so many ways.
@@ -575,7 +575,7 @@ class Object_Sync_Sf_WordPress {
 		*/
 
 		foreach ( $data_fields as $key => $value ) {
-			if ( ! in_array( $value, $ignore_keys, true ) ) {
+			if ( ! in_array( $value, (array) $ignore_keys, true ) ) {
 				$editable = true;
 				if ( $value === $id_field ) {
 					$editable = false;
@@ -592,7 +592,7 @@ class Object_Sync_Sf_WordPress {
 		}
 
 		foreach ( $meta_fields as $key => $value ) {
-			if ( ! in_array( $value->meta_key, $ignore_keys, true ) ) {
+			if ( ! in_array( $value->meta_key, (array) $ignore_keys, true ) ) {
 				$editable = true;
 				if ( $value === $id_field ) {
 					$editable = false;

--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -997,9 +997,10 @@ class Object_Sync_Sf_WordPress {
 				do_action( $this->option_prefix . 'set_more_user_data', $user_id, $params, 'create' );
 
 				// Send notification of new user.
-				// todo: Figure out what permissions ought to get notifications for this and make sure it works the right way.
-				wp_new_user_notification( $user_id, null, 'both' );
-
+				// todo: Figure out what permissions ought to get notifications for this and make sure it works the right way. In the meantime, allow developers to prevent the notification from being sent.
+				if ( apply_filters( $this->option_prefix . 'send_new_user_notification', true, $user_id, $params ) ) {
+					wp_new_user_notification( $user_id, null, 'both' );
+				}
 			}
 		} else {
 			$user_id = username_exists( $username );

--- a/classes/class-object-sync-sf-wordpress.php
+++ b/classes/class-object-sync-sf-wordpress.php
@@ -537,7 +537,7 @@ class Object_Sync_Sf_WordPress {
 	 * @param array  $ignore_keys Fields to ignore from the database.
 	 * @return array $all_fields The fields for the object.
 	 */
-	private function object_fields( $object_name, $id_field, $content_table, $content_methods, $meta_table, $meta_methods, $where, $ignore_keys = [] ) {
+	private function object_fields( $object_name, $id_field, $content_table, $content_methods, $meta_table, $meta_methods, $where, $ignore_keys = array() ) {
 		// These two queries load all the fields from the specified object unless they have been specified as ignore fields.
 		// They also load the fields that are meta_keys from the specified object's meta table.
 		// Maybe a box for a custom query, since custom fields get done in so many ways.


### PR DESCRIPTION
## What does this Pull Request do?

- When some options aren't selected, options return non-array values and `in_array` calls fatal out. Let's cast them into arrays to be sure. In some cases, `maybe_unserialize` is not returning the default array values.
- Updated some of the variable domdocs.
- Added filter to prevent user creation from sending a notification (see inline note).

