### PR TITLE
Fix offset calculation to avoid losing offset record updates

### DIFF
--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -536,9 +536,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 					} // end if
 				} // end foreach
 
-				// we're done with the foreach. store the LastModifiedDate of the last item processed, or the current time if it isn't there.
+				// we're done with the foreach. save  the LastModifiedDate of the last item processed, we will store it if the query has results with an additional offset.
 				$last_date_for_query = isset( $result['LastModifiedDate'] ) ? $result['LastModifiedDate'] : '';
-				$this->increment_current_type_datetime( $type, $last_date_for_query, $salesforce_mapping['id'] );
 
 				if ( true === $this->batch_soql_queries ) {
 					// if applicable, process the next batch of records.
@@ -552,6 +551,8 @@ class Object_Sync_Sf_Salesforce_Pull {
 					end( $response['records'] );
 					$last_record_key = key( $response['records'] );
 					if ( true === $does_next_offset_have_results ) {
+						// store the LastModifiedDate of the last item processed, or the current time if it isn't there.
+						$this->increment_current_type_datetime( $type, $last_date_for_query, $salesforce_mapping['id'] );
 						// increment SOQL query to run.
 						$soql = $this->get_pull_query( $type, $salesforce_mapping );
 					} elseif ( $last_record_key === $key ) {

--- a/classes/class-object-sync-sf-salesforce-pull.php
+++ b/classes/class-object-sync-sf-salesforce-pull.php
@@ -725,6 +725,7 @@ class Object_Sync_Sf_Salesforce_Pull {
 	 *
 	 * @param string $type e.g. "Contact", "Account", etc.
 	 * @param array  $salesforce_mapping the fieldmap that maps the two object types.
+	 * @param bool $force_current_offset if true, the will not be recalculated and will use the offset of the current query saved on the db, if present.
 	 * @return Object_Sync_Sf_Salesforce_Select_Query or null if no mappings or no mapped fields were found.
 	 * @see Object_Sync_Sf_Mapping::get_mapped_fields
 	 * @see Object_Sync_Sf_Mapping::get_mapped_record_types


### PR DESCRIPTION
## What does this Pull Request do?

This PR fixes the issue #541 by changing how the offset is calculated to avoid losing record updates when pulling data from SalesForce.  I made the following changes:

- Added a a third param to get_pull_query function: when true the offset for the new query is not calculated. This way when calling get_pull_query for the first time during the object_sync_for_salesforce_pull_check_records action the offset is not added two times.  
- increment_current_type_datetime is called when the does_next_offset_have_results variable is true. I made this change following this logic:

1. after writing the items to the queue, another query is sent with an additional offset to check if there are results, using the current LastModifiedDate.
2. If there are results, store in db the LastModifiedDate of the last item processed during the first query.
3. the get_pull_query gets called a third time. Now if the LastModifiedDate is equal to the previous one the correct offset is used, otherwise the offset gets removed and the condition uses the last value.

## How do I test this Pull Request?

- Map some entities between WordPress and Salesforce
-  Update some data in Salesforce
- Make some pull operations and check if data is saved.
