### PR TITLE
Fix warning triggered in WordPress 6.7 and newer due to translation functions being called too early in the plugin lifecycle. Thanks to @alessandrocarrera for the report and @richaber for additional context.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* 2.2.12 (2025-)
+	* Plugin status: Plugin status: as before, this plugin doesn't currently have official maintainers. I try to check in occasionally if anyone submits pull requests or major issues and merge them if I can do so rather quickly. Updates will be given within the plugin if/when that status changes.
+	* Bug fix: Fix warning triggered in WordPress 6.7 and newer due to translation functions being called too early in the plugin lifecycle. Thanks to GitHub user @alessandrocarrera for the report and @richaber for additional context.
+
 * 2.2.11 (2024-10-08)
 	* Plugin status: Plugin status: as before, this plugin doesn't currently have official maintainers. I try to check in occasionally if anyone submits pull requests or major issues and merge them if I can do so rather quickly. Updates will be given within the plugin if/when that status changes.
 	* Bug fix: Fix offset calculation to avoid losing offset record updates. Thanks to @HyprCoder for the fix.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* 2.2.12 (2025-)
+	* Plugin status: Plugin status: as before, this plugin doesn't currently have official maintainers. I try to check in occasionally if anyone submits pull requests or major issues and merge them if I can do so rather quickly. Updates will be given within the plugin if/when that status changes.
+	* Bug fix: Fix warning triggered in WordPress 6.7 and newer due to translation functions being called too early in the plugin lifecycle. Thanks to GitHub user @alessandrocarrera for the report and @richaber for additional context.
+
 * 2.2.11 (2024-10-08)
 	* Plugin status: Plugin status: as before, this plugin doesn't currently have official maintainers. I try to check in occasionally if anyone submits pull requests or major issues and merge them if I can do so rather quickly. Updates will be given within the plugin if/when that status changes.
 	* Bug fix: Fix offset calculation to avoid losing offset record updates. Thanks to @HyprCoder for the fix.

--- a/classes/class-object-sync-sf-admin.php
+++ b/classes/class-object-sync-sf-admin.php
@@ -134,13 +134,6 @@ class Object_Sync_Sf_Admin {
 	private $admin_settings_url_param;
 
 	/**
-	 * Data for admin notices
-	 *
-	 * @var array
-	 */
-	public $notices_data;
-
-	/**
 	 * Salesforce access token
 	 *
 	 * @var string
@@ -241,7 +234,6 @@ class Object_Sync_Sf_Admin {
 
 		$this->sfwp_transients          = object_sync_for_salesforce()->wordpress->sfwp_transients;
 		$this->admin_settings_url_param = 'object-sync-salesforce-admin';
-		$this->notices_data             = $this->notices_data();
 
 		// default authorize url path.
 		$this->default_authorize_url_path = '/services/oauth2/authorize';
@@ -1428,7 +1420,7 @@ class Object_Sync_Sf_Admin {
 	 *
 	 * @return array $notices is the array of notices.
 	 */
-	public function notices_data() {
+	public function get_notices_data() {
 		$notices = array(
 			'permission'              => array(
 				'condition'   => ( false === $this->check_wordpress_admin_permissions() ),
@@ -1525,7 +1517,7 @@ class Object_Sync_Sf_Admin {
 		}
 
 		$get_data = filter_input_array( INPUT_GET, FILTER_SANITIZE_SPECIAL_CHARS );
-		$notices  = $this->notices_data();
+		$notices  = $this->get_notices_data();
 
 		foreach ( $notices as $key => $value ) {
 

--- a/classes/class-object-sync-sf-mapping.php
+++ b/classes/class-object-sync-sf-mapping.php
@@ -323,8 +323,8 @@ class Object_Sync_Sf_Mapping {
 		$this->object_map_table = $this->wpdb->prefix . 'object_sync_sf_object_map';
 
 		$this->fieldmap_statuses          = array(
-			'active'   => esc_html__( 'Active', 'object-sync-for-salesforce' ),
-			'inactive' => esc_html__( 'Inactive', 'object-sync-for-salesforce' ),
+			'active'   => 'Active',
+			'inactive' => 'Inactive',
 			'any'      => '',
 		);
 		$this->active_fieldmap_conditions = array(
@@ -390,6 +390,27 @@ class Object_Sync_Sf_Mapping {
 		// use the option value for whether we're in debug mode.
 		$this->debug = filter_var( get_option( $this->option_prefix . 'debug_mode', false ), FILTER_VALIDATE_BOOLEAN );
 
+		// action hooks.
+		$this->add_actions();
+	}
+
+	/**
+	 * Run init actions.
+	 */
+	public function add_actions() {
+		// public actions.
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Initialize. things that have to run after init.
+	 */
+	public function init() {
+		$this->fieldmap_statuses = array(
+			'active'   => esc_html__( 'Active', 'object-sync-for-salesforce' ),
+			'inactive' => esc_html__( 'Inactive', 'object-sync-for-salesforce' ),
+			'any'      => '',
+		);
 	}
 
 	/**
@@ -1362,5 +1383,4 @@ class Object_Sync_Sf_Mapping {
 		}
 		return $error;
 	}
-
 }


### PR DESCRIPTION
## What does this Pull Request do?

This should fix #548, in which WordPress versions after 6.7.0 show a notice about translation being triggered too early. This makes very minor changes, which should not affect the tasks that the plugin needs to run early, while still preventing translations from being triggered before they should be.

## How do I test this Pull Request?

- Make sure the notices don't appear
- Make sure push and pull schedules for data to and from Salesforce still work correctly