### PR TITLE
Prevent errors that can occur when saving log settings and schedule settings on initial plugin setup

### DIFF
--- a/classes/class-object-sync-sf-logging.php
+++ b/classes/class-object-sync-sf-logging.php
@@ -353,6 +353,11 @@ class Object_Sync_Sf_Logging extends WP_Logging {
 				$clear_schedule = true;
 			}
 		}
+
+		if ( false === wp_get_scheduled_event( $this->schedule_name ) ) {
+			$clear_schedule = false;
+		}
+
 		if ( true === $clear_schedule ) {
 			wp_clear_scheduled_hook( $this->schedule_name );
 			$this->save_log_schedule();

--- a/classes/class-object-sync-sf-queue.php
+++ b/classes/class-object-sync-sf-queue.php
@@ -132,7 +132,7 @@ class Object_Sync_Sf_Queue {
 		} else {
 			uasort(
 				$this->schedulable_classes,
-				function( $a, $b ) {
+				function ( $a, $b ) {
 					return $b['frequency'] - $a['frequency'];
 				}
 			);
@@ -150,8 +150,17 @@ class Object_Sync_Sf_Queue {
 	 * @return int How often it runs in that unit of time
 	 */
 	public function get_frequency( $name, $unit ) {
-		$schedule_number = filter_var( get_option( $this->option_prefix . $name . '_schedule_number', '' ), FILTER_VALIDATE_INT );
+		$schedule_number = get_option( $this->option_prefix . $name . '_schedule_number', '' );
 		$schedule_unit   = get_option( $this->option_prefix . $name . '_schedule_unit', '' );
+
+		// make sure we have something saved in the options so it doesn't fail.
+		if ( '' === $schedule_number ) {
+			$schedule_number = 0;
+		}
+
+		if ( '' === $schedule_unit ) {
+			$schedule_unit = 'minutes';
+		}
 
 		switch ( $schedule_unit ) {
 			case 'minutes':
@@ -171,7 +180,8 @@ class Object_Sync_Sf_Queue {
 				$minutes = 0;
 		}
 
-		$total = $$unit * $schedule_number;
+		$schedule_number = filter_var( $schedule_number, FILTER_SANITIZE_NUMBER_INT );
+		$total           = $$unit * $schedule_number;
 
 		return $total;
 	}


### PR DESCRIPTION
## What does this Pull Request do?

When setting up the plugin, WordPress can encounter errors saving the schedule settings. Additionally, it sometimes flags an error when the Log Settings are initially saved. This fixes both occurrences.

## How do I test this Pull Request?

- do a new install of the plugin
- see that errors do not appear in the logs
- see that scheduled pull tasks still run as they should after the schedule settings are saved